### PR TITLE
More documentation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2](https://github.com/ASFHyP3/hyp3-sdk/compare/v0.2.1...v0.2.2)
+
+### Added
+- typehints and docstrings throughout the SDK for auto-documentation of the API
+
+### Changed
+- Documentation now is mainly contained [The HyP3 Docs](https://asfhyp3.github.io/)
+  and the README just contains quick installation and usage information
+
 ## [0.2.1](https://github.com/ASFHyP3/hyp3-sdk/compare/v0.2.0...v0.2.1)
 
 ### Changed
@@ -19,11 +28,12 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.1.1](https://github.com/ASFHyP3/hyp3-sdk/compare/v0.1.0...v0.1.1)
 
 ### Fixed
-- removed space from auth url that prevents successful sign in
+- Removed space from auth URL that prevents successful sign in
 
 ## [0.1.0](https://github.com/ASFHyP3/hyp3-sdk/compare/v0.0.0...v0.1.0)
 
 ### Added
 - HyP3 module
-  - HyP3 class which wraps a hyp3 api
-  - Job class used to define Jobs to submit, create witht the factory funcions `make_[job_type]_job()`
+  - HyP3 class which wraps a hyp3 API
+  - Job class used to define Jobs to submit and are created with the `make_[job_type]_job()`
+     factory functions

--- a/README.md
+++ b/README.md
@@ -10,84 +10,38 @@ The HyP3 SDK can be installed via `pip`:
 python -m pip install hyp3_sdk
 ```
 
-## Usage
+## Quick Usage
 
-### The HyP3 object
 The HyP3 object interactions with the HyP3 API are done using an instance of the `HyP3` class
 ```python
 from hyp3_sdk import HyP3
 
 api = HyP3()  # Must have credentials for urs.earthdata.nasa.gov in a .netrc file for this to work
 ```
-If you want to use an API other then the one at <https://hyp3-api.asf.alaska.edu>, you may provide the URL (including scheme) as a parameter
-```python
-from hyp3_sdk import HyP3
-
-api = HyP3('https://hyp3.example.com')
-```
-If you want to pass in a [Requests](https://requests.readthedocs.io/en/latest/user/advanced/) `Session` object for the API to use, it must first be authenticated and then it can be passed into the API
-```python
-import requests
-from hyp3_sdk import HyP3
-
-session = requests.Session()
-session.get(...)  # Authenticate
-
-api = HyP3(authenticated_session=session)
-```
-
-#### Getting jobs
 The `get_jobs` method with request all jobs from the API and return them in a list of dictionaries
 ```python
-from hyp3_sdk import HyP3
-
-api = HyP3()
-
 response = api.get_jobs()
 ```
-##### Parameters:
-- `start`: `datetime` -> requests only jobs submitted after given time
-- `end`: `datetime` -> requests only jobs submitted before given time
-- `status`: `str` -> request based on status (`SUCCEEDED`, `FAILED`, `RUNNING`, `PENDING`)
-- `name`: `str` -> requests only jobs that have this name
 
-#### Submitting jobs
 The `submit_jobs` method will submit jobs to the API for processing
 ```python
-from hyp3_sdk import HyP3, make_rtc_gamma_job
-
-api = HyP3()
+from hyp3_sdk import make_rtc_gamma_job
 
 jobs = [make_rtc_gamma_job('job_name', 'granule_name')]
 
 response = api.submit_jobs(jobs)
 ```
-##### Parameters
-- `jobs`: `list[Job]` -> list of job objects to submit to API
 
-### The Job object
-Job objects represent a job to be submitted to the API, they are made by calling factory functions
+## Documentation
 
-#### Job factories
-- `make_rtc_gamma_job`
-  
-    ##### Parameters   
-    - `job_name`: `str` -> name of job
-    - `granule`: `str` -> name of granule to process
-    - `extra_parameters`: `dict` -> extra parameters and processing options
+For advanced usage and the SDK API Reference, see [the HyP3 documentation](https://asfhyp3.github.io/)
 
-- `make_insar_gamma_job`
-  
-    ##### Parameters   
-    - `job_name`: `str` -> name of job
-    - `granule1`: `str` -> name of primary granule to process
-    - `granule2`: `str` -> name of secondary granule to process
-    - `extra_parameters`: `dict` -> extra parameters and processing options
+## Contact Us
 
-- `make_autorift_job`
+Want to talk about the HyP3 SDK? We would love to hear from you!
 
-    ##### Parameters   
-    - `job_name`: `str` -> name of job
-    - `granule1`: `str` -> name of primary granule to process
-    - `granule2`: `str` -> name of secondary granule to process
-    - `extra_parameters`: `dict` -> extra parameters and processing options
+Found a bug? Want to request a feature?
+[open an issue](https://github.com/ASFHyP3/hyp3-sdk/issues/new)
+
+General questions? Suggestions? Or just want to talk to the team?
+[chat with us on gitter](https://gitter.im/ASFHyP3/community)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 A python wrapper around the HyP3 API
 
+## Install
+
+The HyP3 SDK can be installed via `pip`:
+
+```
+python -m pip install hyp3_sdk
+```
+
 ## Usage
 
 ### The HyP3 object

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -13,7 +13,13 @@ dependencies:
   # For running
   - importlib_metadata
   - requests
+  # For documentation
+  - mkdocs
+  - mkdocs-material
+  - mkdocs-material-extensions
   - pip:
-    # for packaging and testing
+    # For packaging and testing
     - s3pypi
     - safety
+    # For documentation
+    - mkdocstrings

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,37 @@
+# HyP3 SDK documentation
+
+HyP3 SDK documentation is build using [MkDocs](https://www.mkdocs.org/) and the
+[Material theme](https://squidfunk.github.io/mkdocs-material/). 
+
+## How to
+
+### setting up a development environment
+
+From the repository root, you can setup a conda environment with all the 
+necessary dependencies for development of the SDK
+
+```
+conda env create -f conda-env.yml
+conda activate hyp3-sdk
+python -m pip install -e ".[develop]"
+```
+
+### build and view the documentation site
+```
+mkdocs serve
+```
+
+which will allow you to view the documentation at http://127.0.0.1:8000/. This
+make target will automatically watch for new/changed files in this directory and
+rebuild the website so you can see your changes live (just refresh the webpage!).
+
+*Note: Because this captures your terminal (`crtl+c` to exit), it's recommended you
+run this in its own terminal.*
+
+### Deploy
+
+Currently, the SDK documentation is **not deployed** on its own. It is built as
+a single page website and consumed when the general HyP3 documentation is built:
+<https://asfhyp3.github.io/using/sdk/>
+The MkDocs structure here mirrors the HyP3 documentation and is only intended for
+developers to be able to easily view the rendered SDK documentation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,51 @@
+# HyP3 SDK
+
+A python wrapper around the HyP3 API
+
+## Install
+
+The HyP3 SDK can be installed via `pip`:
+
+```
+python -m pip install hyp3_sdk
+```
+
+## Usage
+
+The HyP3 object interactions with the HyP3 API are done using an instance of the `HyP3` class
+```python
+from hyp3_sdk import HyP3
+
+api = HyP3()  # Must have credentials for urs.earthdata.nasa.gov in a .netrc file for this to work
+```
+If you want to use an API other then the one at `https://hyp3-api.asf.alaska.edu`, you may provide 
+the URL (including scheme) as a parameter
+```python
+api = HyP3('https://hyp3.example.com')
+```
+If you want to pass in a [Requests](https://requests.readthedocs.io/en/latest/user/advanced/) `Session`
+object for the API to use, it must first be authenticated and then it can be passed into the API
+```python
+import requests
+
+session = requests.Session()
+session.get(...)  # Authenticate
+
+api = HyP3(authenticated_session=session)
+```
+
+The `get_jobs` method with request all jobs from the API and return them in a list of dictionaries
+```python
+response = api.get_jobs()
+```
+
+The `submit_jobs` method will submit Job objects to the API for processing
+```python
+jobs = [make_rtc_gamma_job('job_name', 'granule_name')]
+
+response = api.submit_jobs(jobs)
+```
+
+## SDK API Reference
+
+::: hyp3_sdk

--- a/hyp3_sdk/exceptions.py
+++ b/hyp3_sdk/exceptions.py
@@ -1,5 +1,6 @@
-"""errors and exceptions thrown by the hyp3 module"""
+"""Errors and exceptions to raise when the SDK runs into problems"""
 
 
 class ValidationError(Exception):
+    """Raise when jobs do not pass validation"""
     pass

--- a/hyp3_sdk/exceptions.py
+++ b/hyp3_sdk/exceptions.py
@@ -3,4 +3,3 @@
 
 class ValidationError(Exception):
     """Raise when jobs do not pass validation"""
-    pass

--- a/hyp3_sdk/hyp3.py
+++ b/hyp3_sdk/hyp3.py
@@ -25,7 +25,8 @@ class HyP3:
         if self.session is None:
             self.session = get_authenticated_session()
 
-    def get_jobs(self, start: datetime = None, end: datetime = None, status: str = None, name: str = None) -> dict:
+    def get_jobs(self, start: Optional[datetime] = None, end: Optional[datetime] = None,
+                 status: Optional[str] = None, name: Optional[str] = None) -> dict:
         """Get your jobs
 
         Args:

--- a/hyp3_sdk/jobs.py
+++ b/hyp3_sdk/jobs.py
@@ -1,4 +1,3 @@
-"""helper functions for making jobs to submit to the api"""
 from hyp3_sdk.exceptions import ValidationError
 
 JOB_TYPES = [
@@ -9,7 +8,15 @@ JOB_TYPES = [
 
 
 class Job:
+    """Jobs to be submitted to the API"""
     def __init__(self, job_type: str, job_name: str, job_parameters: dict = {}):
+        """Create a new Job object
+
+        Args:
+            job_type: The job type
+            job_name: A name for the job (must be < 20 characters)
+            job_parameters: Extra job parameters specifying custom processing options
+        """
         if job_type not in JOB_TYPES:
             raise ValidationError(f'Invalid job type: {job_type}, must be one of {JOB_TYPES}')
         if len(job_name) > 20:
@@ -19,6 +26,10 @@ class Job:
         self.job_parameters = job_parameters
 
     def to_dict(self) -> dict:
+        """
+        Returns:
+            A dictionary representation of the Job object
+        """
         return {
             'job_parameters': {
                 **self.job_parameters
@@ -28,17 +39,58 @@ class Job:
         }
 
 
-def make_job(job_type: str, job_name: str, job_parameters: dict) -> Job:
+def make_job(job_type: str, job_name: str, job_parameters: dict = {}) -> Job:
+    """Make a generic Job object
+
+    Args:
+        job_type: The job type
+        job_name: A name for the job (must be < 20 characters)
+        job_parameters: Extra job parameters specifying custom processing options
+
+    Returns:
+        A Job object
+    """
     return Job(job_type, job_name, job_parameters)
 
 
 def make_autorift_job(job_name: str, granule1: str, granule2: str) -> Job:
+    """Make an autoRIFT Job object
+
+    Args:
+        job_name: A name for the job (must be < 20 characters)
+        granule1: The first granule (scene) to use
+        granule2: The second granule (scene) to use
+
+    Returns:
+        A Job object
+    """
     return Job('AUTORIFT', job_name, {'granules': [granule1, granule2]})
 
 
 def make_rtc_gamma_job(job_name: str, granule: str, extra_parameters: dict = {}) -> Job:
+    """Make an RTC Job object
+
+    Args:
+        job_name: A name for the job (must be < 20 characters)
+        granule: The granule (scene) to process
+        extra_parameters: Extra job parameters specifying custom processing options
+
+    Returns:
+        A Job object
+    """
     return Job('RTC_GAMMA', job_name, {'granules': [granule], **extra_parameters})
 
 
 def make_insar_gamma_job(job_name: str, granule1: str, granule2: str, extra_parameters: dict = {}) -> Job:
+    """Make a InSAR Job object
+
+    Args:
+        job_name: A name for the job (must be < 20 characters)
+        granule1: The first granule (scene) to use
+        granule2: The second granule (scene) to use
+        extra_parameters: Extra job parameters specifying custom processing options
+
+    Returns:
+        A Job object
+    """
     return Job('INSAR_GAMMA', job_name, {'granules': [granule1, granule2], **extra_parameters})

--- a/hyp3_sdk/util.py
+++ b/hyp3_sdk/util.py
@@ -1,11 +1,17 @@
+"""Extra utilities for working with HyP3"""
+
 import requests
 
 AUTH_URL = 'https://urs.earthdata.nasa.gov/oauth/authorize?response_type=code&client_id=BO_n7nTIlMljdvU6kRRB3g' \
            '&redirect_uri=https://auth.asf.alaska.edu/login'
 
 
-def get_authenticated_session():
-    """logs into hyp3 using users credentials for urs.earthdata.nasa.gov in a .netrc file."""
+def get_authenticated_session() -> requests.Session:
+    """logs into hyp3 using users credentials for urs.earthdata.nasa.gov in a .netrc file.
+
+    Returns:
+        An authenticated session
+    """
     s = requests.Session()
     s.get(AUTH_URL)
     return s

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: HyP3
+site_name: SDK
 site_url: https://ASFHyP3.github.io/hyp3-sdk/
 site_author: ASF APD/Tools Team
 site_description: A python wrapper around ASF's HyP3 API
@@ -32,7 +32,7 @@ markdown_extensions:
   - pymdownx.superfences
 
 nav:
-  - Home: index.md
+  - hyp3_sdk: index.md
 
 plugins:
   - mkdocstrings:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,43 @@
+site_name: HyP3
+site_url: https://ASFHyP3.github.io/hyp3-sdk/
+site_author: ASF APD/Tools Team
+site_description: A python wrapper around ASF's HyP3 API
+copyright: © 2020 Alaska Satellite Facility
+google_analytics: ['UA-991100-5', 'search.asf.alaska.edu']
+
+theme:
+  name: "material"
+  icon:
+    repo: fontawesome/brands/github-alt
+  features:
+    - navigation.instant
+
+repo_url: https://github.com/ASFHyP3/hyp3-sdk
+repo_name: HyP3 SDK
+edit_uri: ''
+
+extra:
+  social:
+    - icon: fontawesome/brands/twitter
+      link: https://twitter.com/Ak_Satellite
+    - icon: fontawesome/brands/gitter
+      link: https://gitter.im/ASFHyP3/community
+
+markdown_extensions:
+  - toc:
+      permalink: true
+      toc_depth: 3
+  - admonition
+  - pymdownx.highlight
+  - pymdownx.superfences
+
+nav:
+  - Home: index.md
+
+plugins:
+  - mkdocstrings:
+      watch:
+        - hyp3_sdk
+      handlers:
+        python:
+          inherited_members: True

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: SDK
+site_name: HyP3 SDK
 site_url: https://ASFHyP3.github.io/hyp3-sdk/
 site_author: ASF APD/Tools Team
 site_description: A python wrapper around ASF's HyP3 API
@@ -32,7 +32,7 @@ markdown_extensions:
   - pymdownx.superfences
 
 nav:
-  - hyp3_sdk: index.md
+  - Home: index.md
 
 plugins:
   - mkdocstrings:


### PR DESCRIPTION
* Simplifies the main README
* Sets up a documentation structure
  * SDK API is auto-documented
  * MkDocs site is gernateable/servable for development purposes, but **not deployed**
    * SDK docs are intended to be consumed by the general HyP3 docs when it is built -- see ASFHyP3/ASFHyP3#20
* Add a bunch of docstrings and typehints throughout