### PR TITLE
Correctly specify minimum python version

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,7 +10,7 @@ jobs:
 
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install dependencies
         run: |
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -89,7 +89,7 @@ jobs:
 
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install dependencies
         run: |
@@ -150,7 +150,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: 3.7
+          python-version: 3.8
           activate-environment: hyp3-sdk
           environment-file: conda-env.yml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+- Correctly specifies the minimum python version (3.8) in `setup.py`
 
 ## [0.3.0](https://github.com/ASFHyP3/hyp3-sdk/compare/v0.2.1...v0.2.2)
 

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -11,7 +11,6 @@ dependencies:
   - pytest
   - pytest-cov
   # For running
-  - importlib_metadata
   - python-dateutil
   - requests
   - urllib3

--- a/hyp3_sdk/__init__.py
+++ b/hyp3_sdk/__init__.py
@@ -1,7 +1,6 @@
 """A python wrapper around the HyP3 API"""
 
-# FIXME: Python 3.8+ this should be `from importlib.metadata...`
-from importlib_metadata import PackageNotFoundError, version
+from importlib.metadata import PackageNotFoundError, version
 
 from .config import TESTING  # noqa
 from .hyp3 import HYP3_PROD, HYP3_TEST, HyP3

--- a/setup.py
+++ b/setup.py
@@ -26,14 +26,14 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         ],
 
-    python_requires='~=3.6',
+    python_requires='~=3.8',
 
     install_requires=[
         'python-dateutil',
-        'importlib_metadata',
         'requests',
         'urllib3',
     ],


### PR DESCRIPTION
As of python 3.8, `importlib_metadata` is no longer required so that dependency has been removed. 