### PR TITLE
Better user info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,28 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - `HyP3.prepare_autorift_job`
   - `HyP3.prepare_rtc_job`
   - `HyP3.prepare_insar_job`
+- `HyP3.watch`, `Job.download_files`, and `Batch.download_files` now display progress bars
     
 ### Changed
-- HyP3 `Batch` objects are now iterable
+- HyP3 `Job` objects provide a better string representation
+  ```python
+  >>> print(job)
+  HyP3 RTC_GAMMA job dd884703-cdbf-47ff-848c-de1e2b9917c1
+  ```
+
+- HyP3 `Batch` objects
+  - are now iterable
+  - provide a better string representation
+    ```python
+    >>> print(batch)
+    2 HyP3 Jobs: 0 succeeded, 0 failed, 2 running, 0 pending.
+    ```
+
 - HyP3 submit methods will always return a `Batch` containing the submitted job(s)
 - `HyP3.submit_job_dict` has been renamed to `HyP3.submit_prepared_jobs` and can
   submit one or more prepared job dictionaries.
+- `Job.download_files` and `Batch.download_files` will (optionally) create the
+  download location if it doesn't exist
 
 ## [0.4.0](https://github.com/ASFHyP3/hyp3-sdk/compare/v0.3.3...v0.4.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [0.5.0](https://github.com/ASFHyP3/hyp3-sdk/compare/v0.4.0...v0.5.0)
 
 ### Added
 - Methods to prepare jobs for submission to HyP3

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -16,8 +16,10 @@ dependencies:
   - pytest-cov
   - responses
   # For running
+  - colorama # [win]
   - python-dateutil
   - requests
+  - tqdm
   - urllib3
   - pip:
     # For packaging and testing

--- a/hyp3_sdk/hyp3.py
+++ b/hyp3_sdk/hyp3.py
@@ -96,14 +96,14 @@ class HyP3:
     @watch.register
     def _watch_batch(self, batch: Batch, timeout: int = 10800, interval: Union[int, float] = 60):
         bar_format = '{l_bar}{bar}| {n_fmt}/{total_fmt} [{postfix[0]}]'
-        with tqdm(total=len(batch), bar_format=bar_format, postfix=[f'timout in {timeout} s']) as pbar:
+        with tqdm(total=len(batch), bar_format=bar_format, postfix=[f'timeout in {timeout} s']) as pbar:
             for ii in reversed(range(math.ceil(timeout / interval))):
                 batch = self.refresh(batch)
 
                 counts = batch._count_statuses()
                 complete = counts['SUCCEEDED'] + counts['FAILED']
 
-                pbar.postfix = [f'timout in {(ii + 1) * interval}s']
+                pbar.postfix = [f'timeout in {(ii + 1) * interval}s']
                 # to control n/total manually; update is n += value
                 pbar.n = complete
                 pbar.update(0)
@@ -116,10 +116,10 @@ class HyP3:
     @watch.register
     def _watch_job(self, job: Job, timeout: int = 10800, interval: Union[int, float] = 60):
         bar_format = '{n_fmt}/{total_fmt} [{postfix[0]}]'
-        with tqdm(total=1, bar_format=bar_format, postfix=[f'timout in {timeout} s']) as pbar:
+        with tqdm(total=1, bar_format=bar_format, postfix=[f'timeout in {timeout} s']) as pbar:
             for ii in reversed(range(math.ceil(timeout / interval))):
                 job = self.refresh(job)
-                pbar.postfix = [f'timout in {(ii + 1) * interval}s']
+                pbar.postfix = [f'timeout in {(ii + 1) * interval}s']
                 pbar.update(int(job.complete()))
 
                 if job.complete():

--- a/hyp3_sdk/hyp3.py
+++ b/hyp3_sdk/hyp3.py
@@ -95,10 +95,10 @@ class HyP3:
 
     @watch.register
     def _watch_batch(self, batch: Batch, timeout: int = 10800, interval: Union[int, float] = 60):
-        iterations_until_timout = math.ceil(timeout / interval)
+        iterations_until_timeout = math.ceil(timeout / interval)
         bar_format = '{l_bar}{bar}| {n_fmt}/{total_fmt} [{postfix[0]}]'
         with tqdm(total=len(batch), bar_format=bar_format, postfix=[f'timeout in {timeout} s']) as pbar:
-            for ii in range(iterations_until_timout):
+            for ii in range(iterations_until_timeout):
                 batch = self.refresh(batch)
 
                 counts = batch._count_statuses()
@@ -116,10 +116,10 @@ class HyP3:
 
     @watch.register
     def _watch_job(self, job: Job, timeout: int = 10800, interval: Union[int, float] = 60):
-        iterations_until_timout = math.ceil(timeout / interval)
+        iterations_until_timeout = math.ceil(timeout / interval)
         bar_format = '{n_fmt}/{total_fmt} [{postfix[0]}]'
         with tqdm(total=1, bar_format=bar_format, postfix=[f'timeout in {timeout} s']) as pbar:
-            for ii in range(iterations_until_timout):
+            for ii in range(iterations_until_timeout):
                 job = self.refresh(job)
                 pbar.postfix = [f'timeout in {timeout - ii * interval}s']
                 pbar.update(int(job.complete()))

--- a/hyp3_sdk/hyp3.py
+++ b/hyp3_sdk/hyp3.py
@@ -1,13 +1,13 @@
 import math
 import time
 import warnings
-from datetime import datetime, timedelta
+from datetime import datetime
 from functools import singledispatchmethod
 from typing import List, Optional, Union
 from urllib.parse import urljoin
 
-from tqdm.auto import tqdm
 from requests.exceptions import HTTPError, RequestException
+from tqdm.auto import tqdm
 
 import hyp3_sdk
 from hyp3_sdk.exceptions import HyP3Error
@@ -96,7 +96,7 @@ class HyP3:
     @watch.register
     def _watch_batch(self, batch: Batch, timeout: int = 10800, interval: Union[int, float] = 60):
         bar_format = '{l_bar}{bar}| {n_fmt}/{total_fmt} [{postfix[0]}]'
-        with tqdm(total=len(batch), bar_format=bar_format, postfix=[f'timout in {timeout}s']) as pbar:
+        with tqdm(total=len(batch), bar_format=bar_format, postfix=[f'timout in {timeout} s']) as pbar:
             for ii in reversed(range(math.ceil(timeout / interval))):
                 batch = self.refresh(batch)
 
@@ -116,7 +116,7 @@ class HyP3:
     @watch.register
     def _watch_job(self, job: Job, timeout: int = 10800, interval: Union[int, float] = 60):
         bar_format = '{n_fmt}/{total_fmt} [{postfix[0]}]'
-        with tqdm(total=1, bar_format=bar_format, postfix=[f'timout in {timeout}s']) as pbar:
+        with tqdm(total=1, bar_format=bar_format, postfix=[f'timout in {timeout} s']) as pbar:
             for ii in reversed(range(math.ceil(timeout / interval))):
                 job = self.refresh(job)
                 pbar.postfix = [f'timout in {(ii + 1) * interval}s']

--- a/hyp3_sdk/hyp3.py
+++ b/hyp3_sdk/hyp3.py
@@ -95,15 +95,16 @@ class HyP3:
 
     @watch.register
     def _watch_batch(self, batch: Batch, timeout: int = 10800, interval: Union[int, float] = 60):
+        iterations_until_timout = math.ceil(timeout / interval)
         bar_format = '{l_bar}{bar}| {n_fmt}/{total_fmt} [{postfix[0]}]'
         with tqdm(total=len(batch), bar_format=bar_format, postfix=[f'timeout in {timeout} s']) as pbar:
-            for ii in reversed(range(math.ceil(timeout / interval))):
+            for ii in range(iterations_until_timout):
                 batch = self.refresh(batch)
 
                 counts = batch._count_statuses()
                 complete = counts['SUCCEEDED'] + counts['FAILED']
 
-                pbar.postfix = [f'timeout in {(ii + 1) * interval}s']
+                pbar.postfix = [f'timeout in {timeout - ii * interval}s']
                 # to control n/total manually; update is n += value
                 pbar.n = complete
                 pbar.update(0)
@@ -115,11 +116,12 @@ class HyP3:
 
     @watch.register
     def _watch_job(self, job: Job, timeout: int = 10800, interval: Union[int, float] = 60):
+        iterations_until_timout = math.ceil(timeout / interval)
         bar_format = '{n_fmt}/{total_fmt} [{postfix[0]}]'
         with tqdm(total=1, bar_format=bar_format, postfix=[f'timeout in {timeout} s']) as pbar:
-            for ii in reversed(range(math.ceil(timeout / interval))):
+            for ii in range(iterations_until_timout):
                 job = self.refresh(job)
-                pbar.postfix = [f'timeout in {(ii + 1) * interval}s']
+                pbar.postfix = [f'timeout in {timeout - ii * interval}s']
                 pbar.update(int(job.complete()))
 
                 if job.complete():

--- a/hyp3_sdk/hyp3.py
+++ b/hyp3_sdk/hyp3.py
@@ -1,3 +1,4 @@
+import math
 import time
 import warnings
 from datetime import datetime, timedelta
@@ -94,17 +95,15 @@ class HyP3:
 
     @watch.register
     def _watch_batch(self, batch: Batch, timeout: int = 10800, interval: Union[int, float] = 60):
-        end_time = datetime.now() + timedelta(seconds=timeout)
         bar_format = '{l_bar}{bar}| {n_fmt}/{total_fmt} [{postfix[0]}]'
         with tqdm(total=len(batch), bar_format=bar_format, postfix=[f'timout in {timeout}s']) as pbar:
-            while datetime.now() < end_time:
+            for ii in reversed(range(math.ceil(timeout / interval))):
                 batch = self.refresh(batch)
 
                 counts = batch._count_statuses()
                 complete = counts['SUCCEEDED'] + counts['FAILED']
 
-                time_delta = (end_time - datetime.now()).seconds
-                pbar.postfix = [f'timout in {time_delta}s']
+                pbar.postfix = [f'timout in {(ii + 1) * interval}s']
                 # to control n/total manually; update is n += value
                 pbar.n = complete
                 pbar.update(0)
@@ -116,14 +115,11 @@ class HyP3:
 
     @watch.register
     def _watch_job(self, job: Job, timeout: int = 10800, interval: Union[int, float] = 60):
-        end_time = datetime.now() + timedelta(seconds=timeout)
         bar_format = '{n_fmt}/{total_fmt} [{postfix[0]}]'
         with tqdm(total=1, bar_format=bar_format, postfix=[f'timout in {timeout}s']) as pbar:
-            while datetime.now() < end_time:
+            for ii in reversed(range(math.ceil(timeout / interval))):
                 job = self.refresh(job)
-
-                time_delta = (end_time - datetime.now()).seconds
-                pbar.postfix = [f'timout in {time_delta}s']
+                pbar.postfix = [f'timout in {(ii + 1) * interval}s']
                 pbar.update(int(job.complete()))
 
                 if job.complete():

--- a/hyp3_sdk/hyp3.py
+++ b/hyp3_sdk/hyp3.py
@@ -97,17 +97,17 @@ class HyP3:
     def _watch_batch(self, batch: Batch, timeout: int = 10800, interval: Union[int, float] = 60):
         iterations_until_timeout = math.ceil(timeout / interval)
         bar_format = '{l_bar}{bar}| {n_fmt}/{total_fmt} [{postfix[0]}]'
-        with tqdm(total=len(batch), bar_format=bar_format, postfix=[f'timeout in {timeout} s']) as pbar:
+        with tqdm(total=len(batch), bar_format=bar_format, postfix=[f'timeout in {timeout} s']) as progress_bar:
             for ii in range(iterations_until_timeout):
                 batch = self.refresh(batch)
 
                 counts = batch._count_statuses()
                 complete = counts['SUCCEEDED'] + counts['FAILED']
 
-                pbar.postfix = [f'timeout in {timeout - ii * interval}s']
+                progress_bar.postfix = [f'timeout in {timeout - ii * interval}s']
                 # to control n/total manually; update is n += value
-                pbar.n = complete
-                pbar.update(0)
+                progress_bar.n = complete
+                progress_bar.update(0)
 
                 if batch.complete():
                     return batch
@@ -118,11 +118,11 @@ class HyP3:
     def _watch_job(self, job: Job, timeout: int = 10800, interval: Union[int, float] = 60):
         iterations_until_timeout = math.ceil(timeout / interval)
         bar_format = '{n_fmt}/{total_fmt} [{postfix[0]}]'
-        with tqdm(total=1, bar_format=bar_format, postfix=[f'timeout in {timeout} s']) as pbar:
+        with tqdm(total=1, bar_format=bar_format, postfix=[f'timeout in {timeout} s']) as progress_bar:
             for ii in range(iterations_until_timeout):
                 job = self.refresh(job)
-                pbar.postfix = [f'timeout in {timeout - ii * interval}s']
-                pbar.update(int(job.complete()))
+                progress_bar.postfix = [f'timeout in {timeout - ii * interval}s']
+                progress_bar.update(int(job.complete()))
 
                 if job.complete():
                     return job

--- a/hyp3_sdk/jobs.py
+++ b/hyp3_sdk/jobs.py
@@ -115,12 +115,16 @@ class Job:
         Returns: list of Path objects to downloaded files
         """
         location = Path(location)
+
+        if not self.succeeded():
+            raise HyP3Error(f'Only succeeded jobs can be downloaded; job is {self.status_code}.')
+        if self.expired():
+            raise HyP3Error(f'Expired jobs cannot be downloaded; '
+                            f'job expired {self.expiration_time.isoformat(timespec="seconds")}.')
+
         if create and not location.is_dir():
             location.mkdir(parents=True)
-        if not self.complete():
-            raise HyP3Error('Incomplete jobs cannot be downloaded')
-        if self.expired():
-            raise HyP3Error('Expired jobs cannot be downloaded')
+
         downloaded_files = []
         for file in self.files:
             download_url = file['url']

--- a/hyp3_sdk/jobs.py
+++ b/hyp3_sdk/jobs.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Union
@@ -40,7 +41,10 @@ class Job:
         self.expiration_time = expiration_time
 
     def __repr__(self):
-        return str(self.to_dict())
+        return f'Job.from_dict({self.to_dict()})'
+
+    def __str__(self):
+        return f'HyP3 {self.job_type} job {self.job_id}'
 
     def __eq__(self, other):
         return self.__dict__ == other.__dict__
@@ -144,7 +148,19 @@ class Batch:
         return len(self.jobs)
 
     def __repr__(self):
-        return str([job.to_dict() for job in self.jobs])
+        reprs = ", ".join([job.__repr__() for job in self.jobs])
+        return f'Batch([{reprs}])'
+
+    def __str__(self):
+        count = self._count_statuses()
+        return f'{len(self)} HyP3 Jobs: ' \
+               f'{count["SUCCEEDED"]} succeeded, ' \
+               f'{count["FAILED"]} failed, ' \
+               f'{count["RUNNING"]} running, ' \
+               f'{count["PENDING"]} pending.'
+
+    def _count_statuses(self):
+        return Counter([job.status_code for job in self.jobs])
 
     def complete(self) -> bool:
         """

--- a/hyp3_sdk/jobs.py
+++ b/hyp3_sdk/jobs.py
@@ -132,7 +132,7 @@ class Job:
             try:
                 downloaded_files.append(download_file(download_url, filename, chunk_size=10485760))
             except RequestException:
-                raise HyP3Error('unable to download file')
+                raise HyP3Error(f'Unable to download file: {download_url}')
         return downloaded_files
 
 

--- a/hyp3_sdk/jobs.py
+++ b/hyp3_sdk/jobs.py
@@ -122,8 +122,10 @@ class Job:
             raise HyP3Error(f'Expired jobs cannot be downloaded; '
                             f'job expired {self.expiration_time.isoformat(timespec="seconds")}.')
 
-        if create and not location.is_dir():
-            location.mkdir(parents=True)
+        if create:
+            location.mkdir(parents=True, exist_ok=True)
+        elif not location.is_dir():
+            raise NotADirectoryError(str(location))
 
         downloaded_files = []
         for file in self.files:

--- a/hyp3_sdk/util.py
+++ b/hyp3_sdk/util.py
@@ -4,6 +4,7 @@ from typing import Union
 
 import requests
 from requests.adapters import HTTPAdapter
+from tqdm.auto import tqdm
 from urllib3.util.retry import Retry
 
 import hyp3_sdk
@@ -63,7 +64,8 @@ def download_file(url: str, filepath: Union[Path, str], chunk_size=None, retries
 
     with session.get(url, stream=True) as s:
         s.raise_for_status()
-        with open(filepath, "wb") as f:
+        with tqdm.wrapattr(open(filepath, "wb"), 'write', miniters=1, desc=filepath.name,
+                           total=int(s.headers.get('content-length', 0))) as f:
             for chunk in s.iter_content(chunk_size=chunk_size):
                 if chunk:
                     f.write(chunk)

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'python-dateutil',
         'requests',
         'urllib3',
+        'tqdm',
     ],
 
     extras_require={

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -117,7 +117,7 @@ def test_job_download_files_create_dirs(tmp_path, get_mock_job):
     job = get_mock_job(status_code='SUCCEEDED', expiration_time=unexpired_time,
                        files=[{'url': 'https://foo.com/file', 'size': 0, 'filename': 'file'}])
 
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(NotADirectoryError):
         job.download_files(tmp_path / 'not_a_dir', create=False)
 
     responses.add(responses.GET, 'https://foo.com/file', body='foobar')
@@ -210,7 +210,7 @@ def test_batch_download(tmp_path, get_mock_job):
     assert set(paths) == {tmp_path / 'file1', tmp_path / 'file2', tmp_path / 'file3'}
     assert set(contents) == {'foobar1', 'foobar2', 'foobar3'}
 
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(NotADirectoryError):
         batch.download_files(tmp_path / 'not_a_dir', create=False)
 
     paths = batch.download_files(tmp_path / 'not_a_dir', create=True)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -136,7 +136,6 @@ def test_job_download_files(tmp_path, get_mock_job):
     assert contents == 'foobar2'
 
 
-
 @responses.activate
 def test_job_download_files_expired(tmp_path, get_mock_job):
     expired_time = (datetime.now(tz=tz.UTC) - timedelta(days=7)).isoformat(timespec='seconds')

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,4 +1,3 @@
-import os
 from copy import copy
 from datetime import datetime, timedelta
 


### PR DESCRIPTION
## job/batch string representation

Following best practices, 

### Jobs
* [`__str__`](https://docs.python.org/3/reference/datamodel.html#object.__str__) method causes jobs to print like:
  ```python
  >>> print(job)
  HyP3 RTC_GAMMA job dd884703-cdbf-47ff-848c-de1e2b9917c1
  ```

* [`__repr__`](https://docs.python.org/3/reference/datamodel.html#object.__repr__) method provides a copy-paste-able string representation of initializing the job:
  ```python
  >>> print(repr(job))
  Job.from_dict({'job_type': 'RTC_GAMMA', 'job_parameters': {'granules': ['S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8']}, 'job_id': 'dd884703-cdbf-47ff-848c-de1e2b9917c1', 'status_code': 'RUNNING', 'user_id': 'jhkennedy', 'request_time': '2021-02-16T20:56:04+00:00'})

  ```
### Batches

* [`__str__`](https://docs.python.org/3/reference/datamodel.html#object.__str__) method causes batches to print like:
  ```python
  >>> print(batch)
  2 HyP3 Jobs: 0 succeeded, 0 failed, 2 running, 0 pending.
  ```

* [`__repr__`](https://docs.python.org/3/reference/datamodel.html#object.__repr__) method provides a copy-paste-able string representation of initializing the batch:
  ```python
  >>> print(repr(batch))
  Batch([Job.from_dict({'job_type': 'RTC_GAMMA', 'job_parameters': {'granules': ['S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8']}, 'job_id': 'dd884703-cdbf-47ff-848c-de1e2b9917c1', 'status_code': 'RUNNING', 'user_id': 'jhkennedy', 'request_time': '2021-02-16T20:56:04+00:00'}), Job.from_dict({'job_type': 'RTC_GAMMA', 'job_parameters': {'granules': ['S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8']}, 'job_id': 'dd884703-cdbf-47ff-848c-de1e2b9917c1', 'status_code': 'RUNNING', 'user_id': 'jhkennedy', 'request_time': '2021-02-16T20:56:04+00:00'})])
  ```

## Progress bars:

### `watch`

* jobs
  ```python
  >>> test.watch(job)
  0/1 [timeout in 10800s]
  ```
  with the timeout counting down

* batches
  ```python
  >>> test.watch(batch)
  0%|          | 0/2 [timeout in 10800s]
  ```
  with the progress bar being updated as jobs finish, and the timout counting down

### `download_files`

* jobs
  ```python
  >>> job.download_files(...)
  S1A_IW_20150621T120220_SVP_RTC30_G_gpuned_9FF5.zip:  37%|███▋      | 10.0M/27.3M [00:00<00:01, 12.7MB/s]
  ```

* batches
  ```python
  >>> batch.download_files('_test/boogers')
  S1A_IW_20150621T120220_SVP_RTC30_G_gpuned_9FF5.zip: 100%|█████████████████████████████████████████████████████| 27.3M/27.3M [00:01<00:00, 18.8MB/s]
  S1A_IW_20141227T173304_SHP_RTC30_G_gpuned_1E4D.zip: 100%|█████████████████████████████████████████████████████| 32.7M/32.7M [00:01<00:00, 20.1MB/s]
  S1A_IW_20150621T120220_SVP_RTC30_G_gpuned_716E.zip: 100%|█████████████████████████████████████████████████████| 27.3M/27.3M [00:01<00:00, 19.0MB/s]
  S1A_IW_20150621T120220_SVP_RTC30_G_gpuned_C412.zip: 100%|█████████████████████████████████████████████████████| 27.3M/27.3M [00:01<00:00, 19.0MB/s]
  100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:08<00:00,  2.01s/it]
  ````
  utilizing nested progress bar functionality of tqdm

## Also

* Specifies a chunksize for downloading files (taken from [`hyp3_gamma`](https://github.com/ASFHyP3/hyp3-gamma/blob/bb61c0205d2a6746329ebfce1f62c6d09ee01265/hyp3_gamma/util.py#L13)
* `download_files` will (optionally) create download location if it doesn't exist 
---

fixes #68 
fixes #63 
fixes #62
fixes #57
fixes #48

---
## TODO

- [x] test `download_files` create dir handling
- [x] changelog
