### PR TITLE
Remove unnecessary package

### DIFF
--- a/conda-env.yml
+++ b/conda-env.yml
@@ -16,7 +16,6 @@ dependencies:
   - pytest-cov
   - responses
   # For running
-  - colorama # [win]
   - python-dateutil
   - requests
   - tqdm


### PR DESCRIPTION
colorama makes nested tqdm progress bars better on windows, but it's not required.

We can't include it in the conda-forge build (and still be `noarch`)  so may as well not include it here