### PR TITLE
Faster, cleaner github actions

### DIFF
--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -1,0 +1,55 @@
+name: Distribute to PyPI
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  distribute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools wheel "setuptools-scm[toml]"
+
+      - name: Build distribuion
+        id: build
+        run: |
+          git fetch origin +refs/tags/*:refs/tags/*
+          export SDIST_VERSION=$(python setup.py --version)
+          echo "::set-output name=version::${SDIST_VERSION}"
+          python setup.py sdist bdist_wheel
+
+      - name: upload to PyPI.org
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.TOOLS_PYPI_PAK }}
+
+  verify-distribution:
+    runs-on: ubuntu-latest
+    needs: package
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          mamba-version: "*"
+          channels: conda-forge,nodefaults
+          channel-priority: true
+          python-version: 3.8
+          activate-environment: hyp3-sdk
+          environment-file: environment.yml
+
+      - name: Pip install ${{ needs.package.outputs.SDIST_VERSION }}
+        shell: bash -l {0}
+        run: |
+          python -m pip install hyp3_sdk==${{ needs.package.outputs.SDIST_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
     tags:
       - v*
 
-
 jobs:
   finish:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-and-tag.yml
+++ b/.github/workflows/test-and-tag.yml
@@ -1,4 +1,4 @@
-name: Test and build
+name: Test and tag
 
 on:
   push:
@@ -9,12 +9,6 @@ on:
     branches:
       - main
       - develop
-
-env:
-  S3_PYPI_HOST: hyp3-pypi.s3-website-us-east-1.amazonaws.com
-  AWS_REGION: us-east-1
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
 jobs:
   pytest:
@@ -28,7 +22,9 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          auto-update-conda: true
+          mamba-version: "*"
+          channels: conda-forge,nodefaults
+          channel-priority: true
           python-version: ${{ matrix.python-version }}
           activate-environment: hyp3-sdk
           environment-file: environment.yml
@@ -36,13 +32,12 @@ jobs:
       - name: Pytest in conda environment
         shell: bash -l {0}
         run: |
-          python -m pip install .[develop]
           pytest --cov=hyp3_sdk
 
-
-  package:
+  tag:
     runs-on: ubuntu-latest
     needs: pytest
+    if: github.ref == 'refs/heads/main'
     outputs:
       SDIST_VERSION:  ${{ steps.build.outputs.version }}
     steps:
@@ -52,7 +47,6 @@ jobs:
           token: ${{ secrets.TOOLS_BOT_PAK }}
 
       - name: Get associated PR
-        if: github.ref == 'refs/heads/main'
         uses: helaili/github-graphql-action@2.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}
@@ -64,7 +58,6 @@ jobs:
           sha: ${{ github.sha }}
 
       - name: Get PR labels
-        if: github.ref == 'refs/heads/main'
         uses: helaili/github-graphql-action@2.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}
@@ -74,8 +67,7 @@ jobs:
           owner: ASFHyP3
           name: hyp3-sdk
 
-      - name: Upload a Build Artifact
-        if: github.ref == 'refs/heads/main'
+      - name: Upload query artifacts for debugging
         uses: actions/upload-artifact@v2
         with:
           name: query-responces
@@ -88,11 +80,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade setuptools wheel twine s3pypi "setuptools-scm[toml]" importlib_metadata
           python -m pip install bump2version
 
       - name: Tag version
-        if: github.ref == 'refs/heads/main'
         run: |
           git fetch origin +refs/tags/*:refs/tags/*
           git config user.email "UAF-asf-apd@alaska.edu"
@@ -110,48 +100,3 @@ jobs:
 
           git push --tags
           echo "Tagged version $(git describe --abbrev=0) and pushed back to repo"
-
-      - uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Build distribuion and upload to S3-PyPI
-        id: build
-        run: |
-          git fetch origin +refs/tags/*:refs/tags/*
-          export SDIST_VERSION=$(python setup.py --version)
-          echo "::set-output name=version::${SDIST_VERSION}"
-          python setup.py sdist bdist_wheel
-          echo "Uploading version ${SDIST_VERSION} to S3-PyPI"
-          s3pypi --bucket hyp3-pypi --force --verbose
-
-      - name: Upload to PyPI.org
-        if: github.ref == 'refs/heads/main'
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.TOOLS_PYPI_PAK }}
-
-
-  verify-packaging:
-    runs-on: ubuntu-latest
-    needs: package
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          python-version: 3.8
-          activate-environment: hyp3-sdk
-          environment-file: environment.yml
-
-      - name: Pip install ${{ needs.package.outputs.SDIST_VERSION }}
-        shell: bash -l {0}
-        run: |
-          export SDIST_VERSION=${{ needs.package.outputs.SDIST_VERSION }}
-          python -m pip install hyp3_sdk==${SDIST_VERSION} \
-              --trusted-host "${S3_PYPI_HOST}" \
-              --extra-index-url "http://${S3_PYPI_HOST}"

--- a/environment.yml
+++ b/environment.yml
@@ -23,6 +23,4 @@ dependencies:
   - tqdm
   - urllib3
   - pip:
-    # For packaging and testing
-    - s3pypi
     - -e .[develop]


### PR DESCRIPTION
* moves package build and  pypi distribution to its own workflow
* drop s3pypi
* test and build -> test and tag
* mamba for faster conda env creation