### PR TITLE
pin setup-miniconda to 2.0.1

### DIFF
--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v2.0.1
         with:
           mamba-version: "*"
           channels: conda-forge,nodefaults

--- a/.github/workflows/test-and-tag.yml
+++ b/.github/workflows/test-and-tag.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v2.0.1
         with:
           mamba-version: "*"
           channels: conda-forge,nodefaults


### PR DESCRIPTION
Avoids `ERROR: File "setup.py" not found. Directory cannot be installed in editable mode: /tmp` error introduced with the [2.1.0 release](https://github.com/conda-incubator/setup-miniconda/releases/tag/v2.1.0)

The log output of an example failed action is at https://github.com/ASFHyP3/hyp3-sdk/runs/2231983477?check_suite_focus=true