### PR TITLE
Depreciate hyp3_sdk.asf_search for asf_search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.4.0](https://github.com/ASFHyP3/hyp3-sdk/compare/v1.3.0...v1.4.0)
+
+### Changed
+- `hyp3_sdk.asf_search` is **depreciated** and will be removed in future releases.
+  Functionality is being moved to the [`asf_search`](https://github.com/asfadmin/Discovery-asf_search)
+  Python package, which provides a more comprehensive ASF search experience and is available on conda-forge and PyPI.
+- The `get_metadata` and `get_nearest_neighbors` functions in `hyp3_sdk.asf_search` now return GeoJSON formatted
+  results to be in line with results provided by the `asf_search` package.
+
 ## [1.3.0](https://github.com/ASFHyP3/hyp3-sdk/compare/v1.2.0...v1.3.0)
 
 ### Added

--- a/docs/sdk_example.ipynb
+++ b/docs/sdk_example.ipynb
@@ -143,9 +143,9 @@
     "\n",
     "insar_jobs = sdk.Batch()\n",
     "for reference in tqdm(granules):\n",
-    "    neighbors_metadata = asf_search.get_nearest_neighbors(reference, max_neighbors=2)\n",
-    "    for secondary_metadata in neighbors_metadata:\n",
-    "        insar_jobs += hyp3.submit_insar_job(reference, secondary_metadata['granuleName'], name='insar-example')\n",
+    "    neighbors_geojson = asf_search.get_nearest_neighbors(reference, max_neighbors=2)\n",
+    "    for secondary in neighbors_geojson['features']:\n",
+    "        insar_jobs += hyp3.submit_insar_job(reference, secondary['properties']['sceneName'], name='insar-example')\n",
     "print(insar_jobs)"
    ]
   },

--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   # For running
   - python-dateutil
   - requests
+  - shapely
   - tqdm
   - urllib3
 

--- a/hyp3_sdk/asf_search.py
+++ b/hyp3_sdk/asf_search.py
@@ -57,7 +57,7 @@ def get_nearest_neighbors(granule: str, max_neighbors: int = 2,) -> dict:
     """
     params = {
         'output': 'geojson',  # preferred by DISCOVERY-asf_search
-        'platform': 'S1',
+        'platform': 'Sentinel-1',
         'granule_list': granule,
     }
     response = requests.post(_SEARCH_API, params=params)

--- a/hyp3_sdk/asf_search.py
+++ b/hyp3_sdk/asf_search.py
@@ -71,7 +71,7 @@ def get_nearest_neighbors(granule: str, max_neighbors: int = 2,) -> dict:
 
     params = {
         'output': 'geojson',  # preferred by DISCOVERY-asf_search
-        'platform': 'S1',
+        'platform': 'Sentinel-1',
         'intersectsWith': reference_center_wkt,
         'end': reference['properties']['startTime'],  # includes reference scene
         'beamMode': reference['properties']['beamModeType'],

--- a/hyp3_sdk/asf_search.py
+++ b/hyp3_sdk/asf_search.py
@@ -69,10 +69,6 @@ def get_nearest_neighbors(granule: str, max_neighbors: int = 2,) -> dict:
     reference = references[0]
     reference_center_wkt = shape(reference['geometry']).centroid.wkt
 
-    from pprint import pprint as pp
-    pp(reference)
-    pp(reference_center_wkt)
-
     params = {
         'output': 'geojson',  # preferred by DISCOVERY-asf_search
         'platform': 'S1',
@@ -85,16 +81,10 @@ def get_nearest_neighbors(granule: str, max_neighbors: int = 2,) -> dict:
         'polarization': _get_matching_polarizations(reference['properties']['polarization']),
     }
 
-    pp(params)
-
     response = requests.post(_SEARCH_API, params=params)
     _raise_for_search_status(response)
-    pp(response.json()['features'])
 
     neighbors = sorted(response.json()['features'], key=lambda x: x['properties']['startTime'], reverse=True)
-
-    pp(len(neighbors))
-
     search_results = {'features': neighbors[1:max_neighbors+1], 'type': 'FeatureCollection'}
     return search_results
 

--- a/hyp3_sdk/asf_search.py
+++ b/hyp3_sdk/asf_search.py
@@ -1,9 +1,14 @@
+import warnings
 from typing import Iterable, List, Union
 
 import requests
 from shapely.geometry import shape
 
 from hyp3_sdk.exceptions import ASFSearchError, _raise_for_search_status
+
+warnings.warn('\nhyp3_sdk.asf_search is depreciated and functionality is '
+              'being moved to the asf_search Package available on conda-forge and PyPI. '
+              'See: https://github.com/asfadmin/Discovery-asf_search', FutureWarning)
 
 _SEARCH_API = 'https://api.daac.asf.alaska.edu/services/search/param'
 
@@ -17,6 +22,9 @@ def get_metadata(granules: Union[str, Iterable[str]]) -> Union[dict, List[dict]]
     Returns:
         metadata: GeoJSON Feature or FeatureCollection of the requested granule(s)
     """
+    warnings.warn('hyp3_sdk.asf_search.get_metadata is depreciated. We recommend using asf_search.granule_search '
+                  'instead. See: https://github.com/asfadmin/Discovery-asf_search#usage', FutureWarning)
+
     if isinstance(granules, str):
         granule_list = granules
     else:

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,9 @@ setup(
     install_requires=[
         'python-dateutil',
         'requests',
-        'urllib3',
+        'shapely',
         'tqdm',
+        'urllib3',
     ],
 
     extras_require={

--- a/tests/test_asf_search.py
+++ b/tests/test_asf_search.py
@@ -39,7 +39,7 @@ def test_get_nearest_neighbor():
 
     reference_query = f'{asf_search._SEARCH_API}' \
                       '?output=geojson' \
-                      '&platform=S1' \
+                      '&platform=Sentinel-1' \
                       f'&granule_list={reference}'
 
     reference_response = {'features': [
@@ -64,7 +64,7 @@ def test_get_nearest_neighbor():
 
     stack_query = f'{asf_search._SEARCH_API}' \
                   '?output=geojson' \
-                  '&platform=S1' \
+                  '&platform=Sentinel-1' \
                   '&intersectsWith=POINT+%2882.2556430369368+26.42979676529672%29' \
                   '&end=2016-11-06T00:27:50.000000' \
                   '&beamMode=IW' \

--- a/tests/test_asf_search.py
+++ b/tests/test_asf_search.py
@@ -8,27 +8,29 @@ from hyp3_sdk.exceptions import ASFSearchError
 @responses.activate
 def test_get_metadata_string():
     responses.add(responses.POST, asf_search._SEARCH_API,
-                  json={'results': [
-                      {'productType': 'METADATA_SLC'},
-                      {'productType': 'SLC'},
+                  json={'features': [
+                      {'properties': {'processingLevel': 'METADATA_SLC'}},
+                      {'properties': {'processingLevel': 'SLC'}},
                   ]})
-    assert asf_search.get_metadata('S1B_IW_SLC_') == {'productType': 'SLC'}
+    assert asf_search.get_metadata('S1B_IW_SLC_') == {'properties': {'processingLevel': 'SLC'}}
 
 
 @responses.activate
 def test_get_metadata_list():
     mock_response = {
-        'results': [
-            {'productType': 'GRD_HD'},
-            {'productType': 'METADATA_GRD'},
-            {'productType': 'METADATA_SLC'},
-            {'productType': 'SLC'},
+        'features': [
+            {'properties': {'processingLevel': 'GRD_HD'}},
+            {'properties': {'processingLevel': 'METADATA_GRD'}},
+            {'properties': {'processingLevel': 'METADATA_SLC'}},
+            {'properties': {'processingLevel': 'SLC'}},
         ]
     }
     responses.add(responses.POST, asf_search._SEARCH_API, json=mock_response)
 
-    assert asf_search.get_metadata(['S1B_IW_SLC_', 'S1B_IW_SLC_']) == \
-           [{'productType': 'GRD_HD'}, {'productType': 'SLC'}]
+    assert asf_search.get_metadata(['S1B_IW_SLC_', 'S1B_IW_SLC_']) == {
+        'type': 'FeatureCollection',
+        'features': [{'properties': {'processingLevel': 'GRD_HD'}}, {'properties': {'processingLevel': 'SLC'}}]
+    }
 
 
 @responses.activate
@@ -36,66 +38,65 @@ def test_get_nearest_neighbor():
     reference = 'S1A_IW_SLC__1SDV_20161106T002750_20161106T002817_013814_016338_19F7'
 
     reference_query = f'{asf_search._SEARCH_API}' \
-                      '?output=json' \
+                      '?output=geojson' \
                       '&platform=S1' \
                       f'&granule_list={reference}'
-    reference_response = [[
+
+    reference_response = {'features': [
         {
-            'centerLon': '0.0',
-            'centerLat': '1.0',
-            'startTime': '2016-11-06T00:27:50.000000',
-            'beamMode': 'IW',
-            'flightDirection': 'DESCENDING',
-            'processingLevel': 'SLC',
-            'relativeOrbit': '1',
-            'polarization': 'VV+VH',
-            'lookDirection': 'R',
-        },
-        {
-            'centerLon': 'x',
-            'centerLat': 'x',
-            'startTime': 'x',
-            'beamMode': 'x',
-            'flightDirection': 'x',
-            'processingLevel': 'METADATA_SLC',
-            'relativeOrbit': 'x',
-            'polarization': 'x',
-            'lookDirection': 'x',
-        },
-    ]]
+            'geometry': {
+                'coordinates': [[[80.848305, 25.82291], [81.164093, 27.446077], [83.678406, 27.034683],
+                             [83.32576, 25.408642], [80.848305, 25.82291]]],
+                'type': 'Polygon'
+            },
+            'properties': {'beamModeType': 'IW',
+                       'flightDirection': 'DESCENDING',
+                       'pathNumber': '92',
+                       'polarization': 'VV+VH',
+                       'processingLevel': 'SLC',
+                       'startTime': '2016-11-06T00:27:50.000000',
+                       },
+            'type': 'Feature'
+        }
+    ], 'type': 'FeatureCollection'}
+
     responses.add(responses.POST, reference_query, json=reference_response)
 
     stack_query = f'{asf_search._SEARCH_API}' \
-                  '?output=jsonlite' \
+                  '?output=geojson' \
                   '&platform=S1' \
-                  '&intersectsWith=POINT+(0.0+1.0)' \
+                  '&intersectsWith=POINT+%2882.2556430369368+26.42979676529672%29' \
                   '&end=2016-11-06T00:27:50.000000' \
                   '&beamMode=IW' \
                   '&flightDirection=DESCENDING' \
                   '&processingLevel=SLC' \
-                  '&relativeOrbit=1' \
-                  '&polarization=VV%2CVV%2BVH' \
-                  '&lookDirection=R'
+                  '&relativeOrbit=92' \
+                  '&polarization=VV%2CVV%2BVH'
     stack_response = {
-        'results': [
-            {'startTime': 1},
-            {'startTime': 5},
-            {'startTime': 4},
-            {'startTime': 2},
-            {'startTime': 3},
+        'features': [
+            {'properties': {'startTime': 1}},
+            {'properties': {'startTime': 5}},
+            {'properties': {'startTime': 4}},
+            {'properties': {'startTime': 2}},
+            {'properties': {'startTime': 3}},
         ]
     }
     responses.add(responses.POST, stack_query, json=stack_response)
 
-    assert asf_search.get_nearest_neighbors(reference) == \
-           [{'startTime': 4}, {'startTime': 3}]
-    assert asf_search.get_nearest_neighbors(reference, max_neighbors=3) == \
-           [{'startTime': 4}, {'startTime': 3}, {'startTime': 2}]
+    assert asf_search.get_nearest_neighbors(reference) == {
+        'features': [{'properties': {'startTime': 4}}, {'properties': {'startTime': 3}}],
+        'type': 'FeatureCollection'
+    }
+    assert asf_search.get_nearest_neighbors(reference, max_neighbors=3) == {
+        'features': [{'properties': {'startTime': 4}}, {'properties': {'startTime': 3}},
+                     {'properties': {'startTime': 2}}],
+        'type': 'FeatureCollection'
+    }
 
 
 @responses.activate
 def test_get_nearest_neighbors_no_reference():
-    responses.add(responses.POST, asf_search._SEARCH_API, json=[[]])
+    responses.add(responses.POST, asf_search._SEARCH_API, json={'features': []})
     with pytest.raises(ASFSearchError) as e:
         asf_search.get_nearest_neighbors('foo')
     assert 'foo' in str(e)
@@ -103,7 +104,9 @@ def test_get_nearest_neighbors_no_reference():
 
 @responses.activate
 def test_get_nearest_neighbors_no_reference_only_metadata():
-    responses.add(responses.POST, asf_search._SEARCH_API, json=[[{'processingLevel': 'METADATA_SLC'}]])
+    responses.add(responses.POST, asf_search._SEARCH_API, json={
+        'features': [{'properties': {'processingLevel': 'METADATA_GRD'}}]
+    })
     with pytest.raises(ASFSearchError) as e:
         asf_search.get_nearest_neighbors('foo')
     assert 'foo' in str(e)

--- a/tests/test_asf_search.py
+++ b/tests/test_asf_search.py
@@ -46,16 +46,16 @@ def test_get_nearest_neighbor():
         {
             'geometry': {
                 'coordinates': [[[80.848305, 25.82291], [81.164093, 27.446077], [83.678406, 27.034683],
-                             [83.32576, 25.408642], [80.848305, 25.82291]]],
+                                 [83.32576, 25.408642], [80.848305, 25.82291]]],
                 'type': 'Polygon'
             },
             'properties': {'beamModeType': 'IW',
-                       'flightDirection': 'DESCENDING',
-                       'pathNumber': '92',
-                       'polarization': 'VV+VH',
-                       'processingLevel': 'SLC',
-                       'startTime': '2016-11-06T00:27:50.000000',
-                       },
+                           'flightDirection': 'DESCENDING',
+                           'pathNumber': '92',
+                           'polarization': 'VV+VH',
+                           'processingLevel': 'SLC',
+                           'startTime': '2016-11-06T00:27:50.000000',
+                           },
             'type': 'Feature'
         }
     ], 'type': 'FeatureCollection'}


### PR DESCRIPTION
* Provides an import-level warning recommending  [`asf_search`](https://github.com/asfadmin/Discovery-asf_search)
* `get_metadata` issues a warning recommending `asf_search.granule_search`
* All output has been switched to GeoJSON to be in line with results provided by `asf_search`. 