### PR TITLE
rename API URL constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [1.3.0](https://github.com/ASFHyP3/hyp3-sdk/compare/v1.2.0...v1.3.0)
 
 ### Added
-- `extract_zipped_product` function to `util` which will extract zipped HyP3 products
-- `chunk` function to `util` which will split a sequence into small chunks and
+- `extract_zipped_product` function to `hyp3_sdk.util` which will extract zipped HyP3 products
+- `chunk` function to `hyp3_sdk.util` which will split a sequence into small chunks and
   is particularly useful for submitting large batches
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `chunk` function to `util` which will split a sequence into small chunks and
   is particularly useful for submitting large batches
 
+### Changed
+- HyP3 API URL constants have been renamed to be more descriptive
+  - `hyp3_sdk.HyP3_PROD` is now `hyp3_sdk.PROD_API`
+  - `hyp3_sdk.HyP3_TEST` is now `hyp3_sdk.TEST_API`
+
 ## [1.2.0](https://github.com/ASFHyP3/hyp3-sdk/compare/v1.1.3...v1.2.0)
   
 ### Added

--- a/hyp3_sdk/__init__.py
+++ b/hyp3_sdk/__init__.py
@@ -3,7 +3,7 @@
 from importlib.metadata import PackageNotFoundError, version
 
 from .config import TESTING  # noqa
-from .hyp3 import PROD_API, TEST_API, HyP3
+from .hyp3 import HyP3, PROD_API, TEST_API
 from .jobs import Batch, Job
 
 try:

--- a/hyp3_sdk/__init__.py
+++ b/hyp3_sdk/__init__.py
@@ -3,7 +3,7 @@
 from importlib.metadata import PackageNotFoundError, version
 
 from .config import TESTING  # noqa
-from .hyp3 import HYP3_PROD, HYP3_TEST, HyP3
+from .hyp3 import PROD_API, TEST_API, HyP3
 from .jobs import Batch, Job
 
 try:
@@ -18,8 +18,8 @@ except PackageNotFoundError:
 __all__ = [
     'Batch',
     'HyP3',
-    'HYP3_PROD',
-    'HYP3_TEST',
+    'PROD_API',
+    'TEST_API',
     'Job',
     '__version__',
 ]

--- a/hyp3_sdk/hyp3.py
+++ b/hyp3_sdk/hyp3.py
@@ -11,14 +11,14 @@ from hyp3_sdk.exceptions import HyP3Error, _raise_for_hyp3_status
 from hyp3_sdk.jobs import Batch, Job
 from hyp3_sdk.util import get_authenticated_session, get_tqdm_progress_bar
 
-HYP3_PROD = 'https://hyp3-api.asf.alaska.edu'
-HYP3_TEST = 'https://hyp3-test-api.asf.alaska.edu'
+PROD_API = 'https://hyp3-api.asf.alaska.edu'
+TEST_API = 'https://hyp3-test-api.asf.alaska.edu'
 
 
 class HyP3:
     """A python wrapper around the HyP3 API"""
 
-    def __init__(self, api_url: str = HYP3_PROD, username: Optional[str] = None, password: Optional[str] = None,
+    def __init__(self, api_url: str = PROD_API, username: Optional[str] = None, password: Optional[str] = None,
                  prompt: bool = False):
         """
         Args:


### PR DESCRIPTION
It always feels wrong/weird to:

```
import hyp3_sdk as sdk
hyp3 = sdk.HyP3(sdk.HYP3_TEST)
```
even with the `as sdk` that's still *a lot* of HyP3s on a line. This is a bit better and more descriptive I think (and matches the fn argument name)

```
import hyp3_sdk as sdk
hyp3 = sdk.HyP3(sdk.TEST_API)
```
