### PR TITLE
add include_displacement_maps parameter for insar jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0](https://github.com/ASFHyP3/hyp3/compare/v1.4.0...v1.5.0)
+### Added
+- Exposed new `include_displacement_maps` parameter for `HyP3.prepare_insar_job` and `HyP3.submit_insar_job`, which will
+  cause both a line-of-sight displacement and a vertical displacement GeoTIFF to be included in the product.
+
+### Depreciated
+- The `include_los_displacement` parameter of `HyP3.prepare_insar_job` and `HyP3.submit_insar_job` has been
+  depreciated in favor of the `include_displacement_maps` parameter, and will be removed in the future.
+
 ## [1.4.0](https://github.com/ASFHyP3/hyp3-sdk/compare/v1.3.0...v1.4.0)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Exposed new `include_displacement_maps` parameter for `HyP3.prepare_insar_job` and `HyP3.submit_insar_job`, which will
   cause both a line-of-sight displacement and a vertical displacement GeoTIFF to be included in the product.
 
-### Depreciated
+### Deprecated
 - The `include_los_displacement` parameter of `HyP3.prepare_insar_job` and `HyP3.submit_insar_job` has been
-  depreciated in favor of the `include_displacement_maps` parameter, and will be removed in the future.
+  deprecated in favor of the `include_displacement_maps` parameter, and will be removed in the future.
 
 ## [1.4.0](https://github.com/ASFHyP3/hyp3-sdk/compare/v1.3.0...v1.4.0)
 

--- a/hyp3_sdk/hyp3.py
+++ b/hyp3_sdk/hyp3.py
@@ -323,7 +323,8 @@ class HyP3:
                          looks: Literal['20x4', '10x2'] = '20x4',
                          include_dem: bool = False,
                          include_wrapped_phase: bool = False,
-                         apply_water_mask: bool = False) -> Batch:
+                         apply_water_mask: bool = False,
+                         include_displacement_maps: bool = False) -> Batch:
         """Submit an InSAR job
 
         Args:
@@ -339,6 +340,8 @@ class HyP3:
             include_wrapped_phase: Include the wrapped phase GeoTIFF in the product package
             apply_water_mask: Sets pixels over coastal waters and large inland waterbodies
                 as invalid for phase unwrapping
+            include_displacement_maps: Include GeoTIFFs containing displacement values along the Line-Of-Sight (LOS) and
+                vertical directions
 
         Returns:
             A Batch object containing the InSAR job
@@ -359,7 +362,8 @@ class HyP3:
                           looks: Literal['20x4', '10x2'] = '20x4',
                           include_dem: bool = False,
                           include_wrapped_phase: bool = False,
-                          apply_water_mask: bool = False) -> dict:
+                          apply_water_mask: bool = False,
+                          include_displacement_maps: bool = False) -> dict:
         """Submit an InSAR job
 
         Args:
@@ -375,6 +379,8 @@ class HyP3:
             include_wrapped_phase: Include the wrapped phase GeoTIFF in the product package
             apply_water_mask: Sets pixels over coastal waters and large inland waterbodies
                 as invalid for phase unwrapping
+            include_displacement_maps: Include GeoTIFFs containing displacement values along the Line-Of-Sight (LOS) and
+                vertical directions
         Returns:
             A dictionary containing the prepared InSAR job
         """

--- a/hyp3_sdk/hyp3.py
+++ b/hyp3_sdk/hyp3.py
@@ -340,8 +340,7 @@ class HyP3:
             include_wrapped_phase: Include the wrapped phase GeoTIFF in the product package
             apply_water_mask: Sets pixels over coastal waters and large inland waterbodies
                 as invalid for phase unwrapping
-            include_displacement_maps: Include GeoTIFFs containing displacement values along the Line-Of-Sight (LOS) and
-                vertical directions
+            include_displacement_maps: Include displacement maps (line-of-sight and vertical) in the product package
 
         Returns:
             A Batch object containing the InSAR job
@@ -379,8 +378,7 @@ class HyP3:
             include_wrapped_phase: Include the wrapped phase GeoTIFF in the product package
             apply_water_mask: Sets pixels over coastal waters and large inland waterbodies
                 as invalid for phase unwrapping
-            include_displacement_maps: Include GeoTIFFs containing displacement values along the Line-Of-Sight (LOS) and
-                vertical directions
+            include_displacement_maps: Include displacement maps (line-of-sight and vertical) in the product package
         Returns:
             A dictionary containing the prepared InSAR job
         """

--- a/hyp3_sdk/hyp3.py
+++ b/hyp3_sdk/hyp3.py
@@ -1,5 +1,6 @@
 import math
 import time
+import warnings
 from datetime import datetime, timezone
 from functools import singledispatchmethod
 from getpass import getpass
@@ -333,7 +334,8 @@ class HyP3:
             name: A name for the job
             include_look_vectors: Include the look vector theta and phi files in the product package
             include_los_displacement: Include a GeoTIFF in the product package containing displacement values
-                along the Line-Of-Sight (LOS)
+                along the Line-Of-Sight (LOS). This parameter has been deprecated in favor of
+                `include_displacement_maps`, and will be removed in a future release.
             include_inc_map: Include the local and ellipsoidal incidence angle maps in the product package
             looks: Number of looks to take in range and azimuth
             include_dem: Include the digital elevation model GeoTIFF in the product package
@@ -371,7 +373,8 @@ class HyP3:
             name: A name for the job
             include_look_vectors: Include the look vector theta and phi files in the product package
             include_los_displacement: Include a GeoTIFF in the product package containing displacement values
-                along the Line-Of-Sight (LOS)
+                along the Line-Of-Sight (LOS). This parameter has been deprecated in favor of
+                `include_displacement_maps`, and will be removed in a future release.
             include_inc_map: Include the local and ellipsoidal incidence angle maps in the product package
             looks: Number of looks to take in range and azimuth
             include_dem: Include the digital elevation model GeoTIFF in the product package
@@ -382,6 +385,10 @@ class HyP3:
         Returns:
             A dictionary containing the prepared InSAR job
         """
+        if include_los_displacement:
+            warnings.warn('The include_los_displacement parameter has been deprecated in favor of '
+                          'include_displacement_maps, and will be removed in a future release.', UserWarning)
+
         job_parameters = locals().copy()
         for key in ['cls', 'granule1', 'granule2', 'name']:
             job_parameters.pop(key)

--- a/tests/test_hyp3.py
+++ b/tests/test_hyp3.py
@@ -1,3 +1,4 @@
+import warnings
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urljoin
 
@@ -252,6 +253,18 @@ def test_prepare_insar_job():
             'include_displacement_maps': True,
         },
     }
+
+
+def test_deprecated_warning():
+    with warnings.catch_warnings(record=True) as w:
+        HyP3.prepare_insar_job(granule1='my_granule1', granule2='my_granule2', include_los_displacement=False)
+        assert len(w) == 0
+
+    with warnings.catch_warnings(record=True) as w:
+        HyP3.prepare_insar_job(granule1='my_granule1', granule2='my_granule2', include_los_displacement=True)
+        assert len(w) == 1
+        assert issubclass(w[0].category, UserWarning)
+        assert 'deprecated' in str(w[0].message)
 
 
 @responses.activate

--- a/tests/test_hyp3.py
+++ b/tests/test_hyp3.py
@@ -231,11 +231,13 @@ def test_prepare_insar_job():
             'include_dem': False,
             'include_wrapped_phase': False,
             'apply_water_mask': False,
+            'include_displacement_maps': False,
         }
     }
     assert HyP3.prepare_insar_job(granule1='my_granule1',  granule2='my_granule2', name='my_name', looks='10x2',
                                   include_los_displacement=True, include_look_vectors=True, include_inc_map=True,
-                                  include_dem=True, include_wrapped_phase=True, apply_water_mask=True) == {
+                                  include_dem=True, include_wrapped_phase=True, apply_water_mask=True,
+                                  include_displacement_maps=True) == {
         'job_type': 'INSAR_GAMMA',
         'name': 'my_name',
         'job_parameters': {
@@ -247,6 +249,7 @@ def test_prepare_insar_job():
             'include_dem': True,
             'include_wrapped_phase': True,
             'apply_water_mask': True,
+            'include_displacement_maps': True,
         },
     }
 


### PR DESCRIPTION
Need to add docstring language about the `include_los_displacement` parameter being depreciated.

Is it appropriate to log a warning when these functions are called with the depreciated parameter?