### PR TITLE
Remove duplicated period in download warning

### DIFF
--- a/hyp3_sdk/jobs.py
+++ b/hyp3_sdk/jobs.py
@@ -238,7 +238,7 @@ class Batch:
             try:
                 downloaded_files.extend(job.download_files(location, create))
             except HyP3SDKError as e:
-                print(f'Warning: {e}. Skipping download for {job}.')
+                print(f'Warning: {e} Skipping download for {job}.')
         return downloaded_files
 
     def any_expired(self) -> bool:


### PR DESCRIPTION
Currently, when this error is thrown, it prints warning messages like:
```
Warning: Only succeeded jobs can be downloaded; job is PENDING.. Skipping download for HyP3 AUTORIFT job f978966b-b212-4767-8c46-219b3eb1354f.
```

Note the `..` after `PENDING`. 

This removes that double period.