### PR TITLE
include `hyp3_sdk.util` in `__all__`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 * `hyp3-sdk` now uses a `src` layout per this [recommendation](https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/).
 * `hyp3-sdk` now only uses `pyproject.toml` for package creation now that `setuptools` recommends [not using setup.py](https://setuptools.pypa.io/en/latest/userguide/quickstart.html#setuppy-discouraged).
+* `hyp3_sdk.util` is now included in the main `hyp3_sdk` API and does not need to be imported separately
 
 ## [1.7.3]
 ### Added

--- a/src/hyp3_sdk/__init__.py
+++ b/src/hyp3_sdk/__init__.py
@@ -5,15 +5,17 @@ from importlib.metadata import version
 from .config import TESTING  # noqa
 from .hyp3 import HyP3, PROD_API, TEST_API
 from .jobs import Batch, Job
+from . import util
 
 
 __version__ = version(__name__)
 
 __all__ = [
+    '__version__',
     'Batch',
     'HyP3',
+    'Job',
     'PROD_API',
     'TEST_API',
-    'Job',
-    '__version__',
+    'util',
 ]

--- a/src/hyp3_sdk/__init__.py
+++ b/src/hyp3_sdk/__init__.py
@@ -2,10 +2,10 @@
 
 from importlib.metadata import version
 
+from . import util
 from .config import TESTING  # noqa
 from .hyp3 import HyP3, PROD_API, TEST_API
 from .jobs import Batch, Job
-from . import util
 
 
 __version__ = version(__name__)


### PR DESCRIPTION
This adds the `util` submodule to the `hyp3_sdk` API, which should fix IDE warnings when `hyp3_sdk.util` isn't explicitly imported:

![image](https://user-images.githubusercontent.com/7882693/211939497-b81e35fe-87b1-479c-a445-f7e6fb1f473c.png)

and should also mean we don't need to explicitly call out `util` to document the SDK API reference:
https://github.com/ASFHyP3/hyp3-docs/blob/develop/docs/using/sdk_api.md