### PR TITLE
fix path to README

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     {name="ASF APD/Tools Team", email="uaf-asf-apd@alaska.edu"},
 ]
 description = "A python wrapper around the HyP3 API"
-readme = "src/hyp3_sdk/README.md"
+readme = "README.md"
 license = {text = "BSD-3-Clause"}
 classifiers=[
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
The HyP3 SDK README is at the top level of the repo. This fixes the path to the README so our PyPI project page isn't empty:
![image](https://user-images.githubusercontent.com/7882693/211954725-a4b24cc3-ac30-4c52-9ccf-98d6a229aae5.png)
