### PR TITLE
Issue 170: Adding better error message when user has not accepted the ASF EULA

### DIFF
--- a/src/hyp3_sdk/util.py
+++ b/src/hyp3_sdk/util.py
@@ -78,10 +78,10 @@ def get_authenticated_session(username: str, password: str) -> requests.Session:
         # https://github.com/ASFHyP3/hyp3-sdk/issues/170
         parsed_url = urlparse(response.url)
         query_params = parse_qs(parsed_url.query)
-        err_msg_param = query_params.get("error_msg")
+        err_msg_param = query_params.get('error_msg')
         eula_url_param = query_params.get('resolution_url')
         if err_msg_param is not None and eula_url_param is not None:
-            raise AuthenticationError(f"{err_msg_param[0]}: {eula_url_param[0]}")
+            raise AuthenticationError(f'{err_msg_param[0]}: {eula_url_param[0]}')
         elif err_msg_param is not None:
             raise AuthenticationError(f'{err_msg_param[0]}: {PROFILE_URL}')
         try:

--- a/src/hyp3_sdk/util.py
+++ b/src/hyp3_sdk/util.py
@@ -5,6 +5,7 @@ from zipfile import ZipFile
 
 import requests
 from requests.adapters import HTTPAdapter
+from urllib.parse import parse_qs, urlparse
 from urllib3.util.retry import Retry
 
 import hyp3_sdk
@@ -13,6 +14,7 @@ from hyp3_sdk.exceptions import AuthenticationError
 AUTH_URL = 'https://urs.earthdata.nasa.gov/oauth/authorize?response_type=code&client_id=BO_n7nTIlMljdvU6kRRB3g' \
            '&redirect_uri=https://auth.asf.alaska.edu/login&app_type=401'
 
+PROFILE_URL = 'https://urs.earthdata.nasa.gov/profile'
 
 def extract_zipped_product(zip_file: Union[str, Path], delete: bool = True) -> Path:
     """Extract a zipped HyP3 product
@@ -73,6 +75,15 @@ def get_authenticated_session(username: str, password: str) -> requests.Session:
         return s
     if username is not None and password is not None:
         response = s.get(AUTH_URL, auth=(username, password))
+        # https://github.com/ASFHyP3/hyp3-sdk/issues/170
+        parsed_url = urlparse(response.url)
+        query_params = parse_qs(parsed_url.query)
+        err_msg_param = query_params.get("error_msg")
+        eula_url_param = query_params.get('resolution_url')
+        if err_msg_param is not None and eula_url_param is not None:
+            raise AuthenticationError(f"{err_msg_param[0]}: {eula_url_param[0]}")
+        elif err_msg_param is not None:
+            raise AuthenticationError(f'{err_msg_param[0]}: {PROFILE_URL}')
         try:
             response.raise_for_status()
         except requests.HTTPError:


### PR DESCRIPTION
#170  Currently when a user has not set a "Study Area" or accepted the EULA, they receive a 401 Unauthorized status code when authenticating with the Hyp3 SDK. The get_authenticated_session function raises a generic AuthenticationError whenever the response status code is greater than 399, telling the user that there is a problem with their credentials. 
However, it is possible for the user to get this AuthenticationError even if their credentials are correct. Using the response URL we can learn about why the user is receiving an error from the server. 
For example, if the user has not accepted the EULA, the server will respond with a response url that contains query params that contain useful error messages. 

`https://auth.asf.alaska.edu/login?error=access_denied&error_msg=Pre%20authorization%20required%20for%20this%20application,%20please%20authorize%20by%20visiting%20the%20resolution%20url&resolution_url=https://urs.earthdata.nasa.gov/approve_app?client_id={CLIENT_ID}`

This url has been parsed to produce the new error message

`AuthenticationError: Pre authorization required for this application, please authorize by visiting the resolution url: https://urs.earthdata.nasa.gov/approve_app?client_id={CLIENT_ID}`

The same can be done for the Study Area not being set up in the user's profile

`https://auth.asf.alaska.edu/login?error=access_denied&error_msg=Please%20update%20your%20profile%20for%20application%20required%20attributes%20Study%20Area`

This url has been parsed to produce the new error message

`AuthenticationError: Please update your profile for application required attributes Study Area: https://urs.earthdata.nasa.gov/profile`