### PR TITLE
Show improved authentication errors regardless of whether `.netrc` is used

### DIFF
--- a/src/hyp3_sdk/hyp3.py
+++ b/src/hyp3_sdk/hyp3.py
@@ -21,7 +21,8 @@ class HyP3:
 
     def __init__(self, api_url: str = PROD_API, username: Optional[str] = None, password: Optional[str] = None,
                  prompt: bool = False):
-        """
+        """If username and password are not provided, attempts to use credentials from a `.netrc` file.
+
         Args:
             api_url: Address of the HyP3 API
             username: Username for authenticating to `urs.earthdata.nasa.gov`.

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -25,12 +25,16 @@ def test_get_authenticated_session_eula():
     )
     responses.add(responses.GET, util.AUTH_URL, status=302, headers={'Location': redirect_url})
     responses.add(responses.GET, redirect_url, status=401)
-    with pytest.raises(
-            AuthenticationError,
-            match=r'^Pre authorization required for this application, please authorize by visiting '
-                  r'the resolution url: https://urs\.earthdata\.nasa\.gov/approve_app\?client_id=foo$'
-    ):
+
+    match = (
+        r'^Pre authorization required for this application, please authorize by visiting '
+        r'the resolution url: https://urs\.earthdata\.nasa\.gov/approve_app\?client_id=foo$'
+    )
+    with pytest.raises(AuthenticationError, match=match):
         util.get_authenticated_session('user', 'pass')
+
+    with pytest.raises(AuthenticationError, match=match):
+        util.get_authenticated_session(None, None)
 
 
 @responses.activate
@@ -41,12 +45,16 @@ def test_get_authenticated_session_study_area():
     )
     responses.add(responses.GET, util.AUTH_URL, status=302, headers={'Location': redirect_url})
     responses.add(responses.GET, redirect_url, status=401)
-    with pytest.raises(
-            AuthenticationError,
-            match=r'^Please update your profile for application required attributes Study Area: '
-                  r'https://urs\.earthdata\.nasa\.gov/profile$'
-    ):
+
+    match = (
+        r'^Please update your profile for application required attributes Study Area: '
+        r'https://urs\.earthdata\.nasa\.gov/profile$'
+    )
+    with pytest.raises(AuthenticationError, match=match):
         util.get_authenticated_session('user', 'pass')
+
+    with pytest.raises(AuthenticationError, match=match):
+        util.get_authenticated_session(None, None)
 
 
 @responses.activate


### PR DESCRIPTION
Currently, the improved authentication errors (for Study Area not selected or EULA not accepted) do not show if the credentials were taken from the `.netrc` file. This is a fix for that bug.