### PR TITLE
Support `INSAR_ISCE_BURST` job type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0]
+### Added
+* Added `HyP3.submit_insar_isce_burst_job` and `HyP3.prepare_insar_isce_burst_job` methods for submitting
+  InSAR ISCE burst jobs to HyP3.
+
 ## [2.1.1]
 ### Fixed
 * The `user_id` parameter has been moved to the end of the `HyP3.find_jobs` parameter list, to avoid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.3.0]
-### Added
-* Added `HyP3.submit_insar_isce_burst_job` and `HyP3.prepare_insar_isce_burst_job` methods for submitting
-  InSAR ISCE burst jobs to HyP3.
-
-## [3.3.0]
-### Fixed
-* `running` status now only includes running jobs, and pending jobs have their status.
-
 ## [3.2.0]
 ### Added
 * The HyP3 SDK now explicitly supports Python 3.9-3.12
+* Added `HyP3.submit_insar_isce_burst_job` and `HyP3.prepare_insar_isce_burst_job` methods for submitting
+  InSAR ISCE burst jobs to HyP3.
+
 ### Removed
 * Support for Python 3.8 has been dropped.
+
+### Fixed
+* `running` status now only includes running jobs, and pending jobs have their status.
 
 ## [3.1.0]
 ### Added

--- a/src/hyp3_sdk/hyp3.py
+++ b/src/hyp3_sdk/hyp3.py
@@ -442,7 +442,7 @@ class HyP3:
                                      name: Optional[str] = None,
                                      apply_water_mask: bool = False,
                                      looks: Literal['20x4', '10x2', '5x1'] = '20x4') -> dict:
-        """Submit an InSAR ISCE burst job.
+        """Prepare an InSAR ISCE burst job.
 
         Args:
             granule1: The first granule (scene) to use

--- a/src/hyp3_sdk/hyp3.py
+++ b/src/hyp3_sdk/hyp3.py
@@ -411,6 +411,62 @@ class HyP3:
             job_dict['name'] = name
         return job_dict
 
+    def submit_insar_isce_burst_job(self,
+                                    granule1: str,
+                                    granule2: str,
+                                    name: Optional[str] = None,
+                                    apply_water_mask: bool = False,
+                                    looks: Literal['20x4', '10x2', '5x1'] = '20x4') -> Batch:
+        """Submit an InSAR ISCE burst job.
+
+        Args:
+            granule1: The first granule (scene) to use
+            granule2: The second granule (scene) to use
+            name: A name for the job
+            apply_water_mask: Set pixels over coastal and large inland water bodies to NoData
+                in wrapped and unwrapped phase GeoTIFFs (after unwrapping)
+            looks: Number of looks to take in range and azimuth
+
+        Returns:
+            A Batch object containing the InSAR ISCE burst job
+        """
+        arguments = locals().copy()
+        arguments.pop('self')
+        job_dict = self.prepare_insar_isce_burst_job(**arguments)
+        return self.submit_prepared_jobs(prepared_jobs=job_dict)
+
+    @classmethod
+    def prepare_insar_isce_burst_job(cls,
+                                     granule1: str,
+                                     granule2: str,
+                                     name: Optional[str] = None,
+                                     apply_water_mask: bool = False,
+                                     looks: Literal['20x4', '10x2', '5x1'] = '20x4') -> dict:
+        """Submit an InSAR ISCE burst job.
+
+        Args:
+            granule1: The first granule (scene) to use
+            granule2: The second granule (scene) to use
+            name: A name for the job
+            apply_water_mask: Set pixels over coastal and large inland water bodies to NoData
+                in wrapped and unwrapped phase GeoTIFFs (after unwrapping)
+            looks: Number of looks to take in range and azimuth
+
+        Returns:
+            A dictionary containing the prepared InSAR ISCE burst job
+        """
+        job_parameters = locals().copy()
+        for key in ['cls', 'granule1', 'granule2', 'name']:
+            job_parameters.pop(key)
+
+        job_dict = {
+            'job_parameters': {'granules': [granule1, granule2], **job_parameters},
+            'job_type': 'INSAR_ISCE_BURST',
+        }
+        if name is not None:
+            job_dict['name'] = name
+        return job_dict
+
     def my_info(self) -> dict:
         """
         Returns:

--- a/tests/test_hyp3.py
+++ b/tests/test_hyp3.py
@@ -294,6 +294,27 @@ def test_prepare_insar_job():
     }
 
 
+def test_prepare_insar_isce_burst_job():
+    assert HyP3.prepare_insar_isce_burst_job(granule1='my_granule1', granule2='my_granule2') == {
+        'job_type': 'INSAR_ISCE_BURST',
+        'job_parameters': {
+            'granules': ['my_granule1', 'my_granule2'],
+            'apply_water_mask': False,
+            'looks': '20x4',
+        }
+    }
+    assert HyP3.prepare_insar_isce_burst_job(granule1='my_granule1', granule2='my_granule2', name='my_name',
+                                             apply_water_mask=True, looks='10x2') == {
+        'job_type': 'INSAR_ISCE_BURST',
+        'name': 'my_name',
+        'job_parameters': {
+            'granules': ['my_granule1', 'my_granule2'],
+            'apply_water_mask': True,
+            'looks': '10x2',
+        }
+    }
+
+
 def test_deprecated_warning():
     with warnings.catch_warnings(record=True) as w:
         HyP3.prepare_insar_job(granule1='my_granule1', granule2='my_granule2', include_los_displacement=False)
@@ -348,6 +369,21 @@ def test_submit_insar_job(get_mock_job):
         api = HyP3()
     responses.add(responses.POST, urljoin(api.url, '/jobs'), json=api_response)
     batch = api.submit_insar_job('g1', 'g2')
+    assert batch.jobs[0] == job
+
+
+@responses.activate
+def test_submit_insar_isce_burst_job(get_mock_job):
+    job = get_mock_job('INSAR_ISCE_BURST', job_parameters={'granules': ['g1', 'g2']})
+    api_response = {
+        'jobs': [
+            job.to_dict()
+        ]
+    }
+    with patch('hyp3_sdk.util.get_authenticated_session', mock_get_authenticated_session):
+        api = HyP3()
+    responses.add(responses.POST, urljoin(api.url, '/jobs'), json=api_response)
+    batch = api.submit_insar_isce_burst_job('g1', 'g2')
     assert batch.jobs[0] == job
 
 


### PR DESCRIPTION
I named the new functions `submit_insar_isce_burst_job` and `prepare_insar_isce_burst_job` to match the job type `INSAR_ISCE_BURST`, but I'm open to a different naming scheme.

TODO:

- [x] Wait to merge until `INSAR_ISCE_BURST` job type is available in production HyP3.
- [x] Update version number for Changelog entry.