### PR TITLE
Deprecate `HyP3.check_quota` in favor of `HyP3.check_credits`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,14 @@ This release accommodates changes to the HyP3 API schema introduced in HyP3 v6.0
 
 ### Added
 * `credit_cost` attribute to the `Job` class
-* `HyP3.credits_credits` method to determine your remaining processing credits
+* `HyP3.check_credits` method to determine your remaining processing credits
 
 ### Changed
 * `HyP3.my_info()`: A new `remaining_credits` field replaces the `quota` field in the return value
 * `HyP3.check_quota` may return a float or an integer if the user has processing credits
 
 ### Deprecated
-* `HyP3.check_quota` has been deprecated in favor of `hyp3.check_credits`
+* `HyP3.check_quota` has been deprecated in favor of `HyP3.check_credits`
 
 ## [5.0.0]
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This release accommodates changes to the HyP3 API schema introduced in HyP3 v6.0
 
 ### Changed
 * `HyP3.my_info()`: A new `remaining_credits` field replaces the `quota` field in the return value
-* `HyP3.check_quota` now returns a float instead of an integer if the user has processing credits
+* `HyP3.check_quota` may return a float or an integer if the user has processing credits
 
 ### Deprecated
 * `HyP3.check_quota` has been deprecated in favor of `hyp3.check_credits`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,14 @@ This release accommodates changes to the HyP3 API schema introduced in HyP3 v6.0
 
 ### Added
 * `credit_cost` attribute to the `Job` class
+* `HyP3.credits_credits` method to determine your remaining processing credits
 
 ### Changed
-* `HyP3.my_info()`: A new `remaining_credits` field replaces the `quota` field in the return value 
+* `HyP3.my_info()`: A new `remaining_credits` field replaces the `quota` field in the return value
+* `HyP3.check_quota` now returns a float instead of an integer if the user has processing credits
+
+### Deprecated
+* `HyP3.check_quota` has been deprecated in favor of `hyp3.check_credits`
 
 ## [5.0.0]
 ### Removed

--- a/src/hyp3_sdk/hyp3.py
+++ b/src/hyp3_sdk/hyp3.py
@@ -6,6 +6,7 @@ from functools import singledispatchmethod
 from getpass import getpass
 from typing import List, Literal, Optional, Union
 from urllib.parse import urljoin
+from warnings import warn
 
 import hyp3_sdk
 import hyp3_sdk.util
@@ -487,10 +488,20 @@ class HyP3:
         _raise_for_hyp3_status(response)
         return response.json()
 
-    def check_quota(self) -> Optional[int]:
+    def check_credits(self) -> Optional[float]:
         """
         Returns:
             Your remaining processing credits, or None if you have no processing limit
         """
         info = self.my_info()
         return info['remaining_credits']
+
+    def check_quota(self) -> Optional[float]:
+        """Deprecated method for checking your remaining processing credits; replaced by `HyP3.check_credits`
+
+        Returns:
+            Your remaining processing credits, or None if you have no processing limit
+        """
+        warn('This method is deprecated and will be removed in a future release.\n'
+             'Please use `HyP3.check_credits` instead.', DeprecationWarning, stacklevel=2)
+        return self.check_credits()

--- a/src/hyp3_sdk/hyp3.py
+++ b/src/hyp3_sdk/hyp3.py
@@ -488,7 +488,7 @@ class HyP3:
         _raise_for_hyp3_status(response)
         return response.json()
 
-    def check_credits(self) -> Optional[float]:
+    def check_credits(self) -> Union[float, int, None]:
         """
         Returns:
             Your remaining processing credits, or None if you have no processing limit
@@ -496,7 +496,7 @@ class HyP3:
         info = self.my_info()
         return info['remaining_credits']
 
-    def check_quota(self) -> Optional[float]:
+    def check_quota(self) -> Union[float, int, None]:
         """Deprecated method for checking your remaining processing credits; replaced by `HyP3.check_credits`
 
         Returns:

--- a/tests/test_hyp3.py
+++ b/tests/test_hyp3.py
@@ -1,3 +1,4 @@
+import math
 import warnings
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
@@ -411,7 +412,7 @@ def test_my_info():
             'name1',
             'name2'
         ],
-        'remaining_credits': 25,
+        'remaining_credits': 25.,
         'user_id': 'someUser'
     }
     with patch('hyp3_sdk.util.get_authenticated_session', mock_get_authenticated_session):
@@ -422,17 +423,17 @@ def test_my_info():
 
 
 @responses.activate
-def test_check_quota():
+def test_check_credits():
     api_response = {
         'job_names': [
             'name1',
             'name2'
         ],
-        'remaining_credits': 25,
+        'remaining_credits': 25.,
         'user_id': 'someUser'
     }
     with patch('hyp3_sdk.util.get_authenticated_session', mock_get_authenticated_session):
         api = HyP3()
     responses.add(responses.GET, urljoin(api.url, '/user'), json=api_response)
 
-    assert api.check_quota() == 25
+    assert math.isclose(api.check_credits(), 25.)


### PR DESCRIPTION
This:
* adds `HyP3.check_credits` method to check your remaining credits
* deprecates `HyP3.check_quota`
* changes `HyP3.check_quota`'s return type from `Optional[int]` to `Optional[float]`
* changes credits value to float in tests