### PR TITLE
Add STAC creation and Xarray loading functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.0]
+
+### Added
+* New functionality in `stac.py` that allows users to create STAC collections from Batches of HyP3 Burst InSAR jobs
+
 ## [6.0.0]
 This release accommodates changes to the HyP3 API schema introduced in HyP3 v6.0.0
 

--- a/environment.yml
+++ b/environment.yml
@@ -17,9 +17,12 @@ dependencies:
   - pytest
   - pytest-cov
   - responses
-  - pystac
   # For running
   - python-dateutil
   - requests
   - tqdm
   - urllib3
+  - pystac
+  - fsspec
+  - aiohttp
+  - pillow

--- a/environment.yml
+++ b/environment.yml
@@ -22,8 +22,12 @@ dependencies:
   - requests
   - tqdm
   - urllib3
-  # for running stac
+  # For STAC creation
   - pystac
   - fsspec
   - aiohttp
   - tifffile
+  # For data loading
+  - h5py
+  - gdal
+  - odc-stac

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,8 @@ dependencies:
   - requests
   - tqdm
   - urllib3
+  # for running stac
   - pystac
   - fsspec
   - aiohttp
-  - pillow
+  - tifffile

--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - pytest
   - pytest-cov
   - responses
+  - pystac
   # For running
   - python-dateutil
   - requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ dependencies = [
     "requests",
     "urllib3",
     "tqdm",
+    "pystac",
+    "fsspec",
+    "aiohttp",
+    "pillow",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,6 @@ dependencies = [
     "requests",
     "urllib3",
     "tqdm",
-    "pystac",
-    "fsspec",
-    "aiohttp",
-    "tifffile",
 ]
 dynamic = ["version"]
 
@@ -38,7 +34,14 @@ dynamic = ["version"]
 develop = [
     "pytest",
     "pytest-cov",
-    "responses"
+    "responses",
+    "pystac",
+    "fsspec",
+    "aiohttp",
+    "tifffile",
+    "h5py",
+    "gdal",
+    "odc-stac",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pystac",
     "fsspec",
     "aiohttp",
-    "pillow",
+    "tifffile",
 ]
 dynamic = ["version"]
 

--- a/src/hyp3_sdk/load.py
+++ b/src/hyp3_sdk/load.py
@@ -5,6 +5,13 @@ from typing import Iterable, Optional, Tuple
 
 import numpy as np
 
+try:
+    # these imports are dependencies of odc.stac, and don't need to be tried separately
+    import dask
+    import odc.stac as odcstac
+    import xarray as xr
+except ImportError:
+    raise ImportError('odc-stac is required for this module')
 
 try:
     import h5py
@@ -12,21 +19,19 @@ except ImportError:
     raise ImportError('h5py is required for this module')
 
 try:
-    import odc.stac as odcstac
-except ImportError:
-    raise ImportError('odc-stac is required for this module')
-
-try:
     from osgeo import osr
 except ImportError:
     raise ImportError('osgeo/gdal is required for this module')
 
-# these imports are dependencies of odc.stac, and don't need to be tried separately
-import dask
-import h5py
-import pystac
-import xarray as xr
-from pyproj.transformer import Transformer
+try:
+    import pystac
+except ImportError:
+    raise ImportError('pystac is required for this module')
+
+try:
+    from pyproj.transformer import Transformer
+except ImportError:
+    raise ImportError('pyproj is required for this module')
 
 
 osr.UseExceptions()

--- a/src/hyp3_sdk/load.py
+++ b/src/hyp3_sdk/load.py
@@ -16,12 +16,16 @@ try:
 except ImportError:
     raise ImportError('odc-stac is required for this module')
 
+try:
+    from osgeo import osr
+except ImportError:
+    raise ImportError('osgeo/gdal is required for this module')
+
 # these imports are dependencies of odc.stac, and don't need to be tried separately
 import dask
 import h5py
 import pystac
 import xarray as xr
-from osgeo import osr
 from pyproj.transformer import Transformer
 
 

--- a/src/hyp3_sdk/load.py
+++ b/src/hyp3_sdk/load.py
@@ -7,7 +7,6 @@ import dask
 import h5py
 import numpy as np
 import pystac
-import stackstac
 import utm
 import xarray as xr
 from odc import stac as odcstac
@@ -19,19 +18,8 @@ osr.UseExceptions()
 SPEED_OF_LIGHT = 299792458  # m/s
 SENTINEL1 = {
     'carrier_frequency': 5.405e9,  # Hz
-    'altitude': 705e3,  # m, mean value
-    'antenna_length': 12.3,  # m
-    'antenna_width': 0.82,  # m
-    'doppler_bandwidth': 380,  # Hz
-    'pulse_repetition_frequency': 1717.13,  # Hz, based on real data; 1000-3000 (programmable)
-    'chirp_bandwidth': 56.50e6,  # Hz
-    'sampling_frequency': 64.35e6,  # Hz
     'azimuth_pixel_size': 14.1,  # m, this is the ground azimuth pixel spacing, NOT on orbits!
     'range_pixel_size': 2.3,  # m
-    'ground_range_pixel_size': 4.1,  # m
-    'IW1': {'range_resolution': 2.7, 'azimuth_resolution': 22.5},
-    'IW2': {'range_resolution': 3.1, 'azimuth_resolution': 22.7},
-    'IW3': {'range_resolution': 3.5, 'azimuth_resolution': 22.6},
 }
 
 
@@ -278,7 +266,7 @@ def write_mintpy_geometry(outfile: str, dataset: xr.Dataset, metadata: dict) -> 
 
     # Convert from hyp3/gamma to mintpy/isce2 convention
     azimuth_angle = first_product['lv_phi']
-    azimuth_angle = azimuth_angle * 180 / np.pi - 90  # hyp3/gamma to mintpy/isce2 convention
+    azimuth_angle = azimuth_angle * 180 / np.pi - 90
     azimuth_angle = wrap(azimuth_angle, wrap_range=[-180, 180])  # rewrap within -180 to 180
 
     bands = {
@@ -290,7 +278,6 @@ def write_mintpy_geometry(outfile: str, dataset: xr.Dataset, metadata: dict) -> 
     }
     new_dataset = xr.Dataset()
     for name in bands:
-        # dtype = np.bool_ if name == 'water_mask' else np.float32
         new_dataset[name] = bands[name]
         new_dataset[name].attrs['MODIFICATION_TIME'] = str(time.time())
 
@@ -318,8 +305,6 @@ def create_xarray_dataset(
     Returns:
         Xarray dataset
     """
-    # Not sure if stackstac is the best package to use. Could also use odc-stac as for example.
-    # dataset = stackstac.stack(stac_items, chunksize=chunksize, fill_value=0)
     dataset = odcstac.load(stac_items, chunks=chunksize)
 
     if select_bands:

--- a/src/hyp3_sdk/prep_mintpy.py
+++ b/src/hyp3_sdk/prep_mintpy.py
@@ -1,0 +1,279 @@
+import datetime as dt
+import time
+
+import numpy as np
+import pystac
+import stackstac
+import utm
+import xarray as xr
+from osgeo import osr
+
+
+osr.UseExceptions()
+
+SPEED_OF_LIGHT = 299792458  # m/s
+SENTINEL1 = {
+    'carrier_frequency': 5.405e9,  # Hz
+    'altitude': 705e3,  # m, mean value
+    'antenna_length': 12.3,  # m
+    'antenna_width': 0.82,  # m
+    'doppler_bandwidth': 380,  # Hz
+    'pulse_repetition_frequency': 1717.13,  # Hz, based on real data; 1000-3000 (programmable)
+    'chirp_bandwidth': 56.50e6,  # Hz
+    'sampling_frequency': 64.35e6,  # Hz
+    'azimuth_pixel_size': 14.1,  # m, this is the ground azimuth pixel spacing, NOT on orbits!
+    'range_pixel_size': 2.3,  # m
+    'ground_range_pixel_size': 4.1,  # m
+    'IW1': {'range_resolution': 2.7, 'azimuth_resolution': 22.5},
+    'IW2': {'range_resolution': 3.1, 'azimuth_resolution': 22.7},
+    'IW3': {'range_resolution': 3.5, 'azimuth_resolution': 22.6},
+}
+
+
+def incidence_angle2slant_range_distance(atr, inc_angle):
+    """Calculate the corresponding slant range distance given an incidence angle
+
+    Law of sines:
+               r + H                   r               range_dist
+       --------------------- = ----------------- = ------------------ = 2R
+        sin(pi - inc_angle)     sin(look_angle)     sin(range_angle)
+
+    where range_angle = inc_angle - look_angle
+          R is the radius of the circumcircle.
+
+    link: http://www.ambrsoft.com/TrigoCalc/Triangle/BasicLaw/BasicTriangle.htm
+
+    Parameters: atr         - dict, metadata including the following items:
+                                  EARTH_RADIUS
+                                  HEIGHT
+                inc_angle   - float / np.ndarray, incidence angle in degree
+    Returns:    slant_range - float, slant range distance
+    """
+    inc_angle = inc_angle / 180 * np.pi
+    r = float(atr['EARTH_RADIUS'])
+    H = float(atr['HEIGHT'])
+
+    # calculate 2R based on the law of sines
+    R2 = (r + H) / np.sin(np.pi - inc_angle)
+
+    look_angle = np.arcsin(r / R2)
+    range_angle = inc_angle - look_angle
+    range_dist = R2 * np.sin(range_angle)
+
+    return range_dist
+
+
+def utm2latlon(meta, easting, northing):
+    """Convert UTM easting/northing in meters to lat/lon in degrees.
+
+    Parameters: meta     - dict, mintpy attributes that includes:
+                           UTM_ZONE
+                easting  - scalar or 1/2D np.ndarray, UTM    coordinates in x direction
+                northing - scalar or 1/2D np.ndarray, UTM    coordinates in y direction
+    Returns:    lat      - scalar or 1/2D np.ndarray, WGS 84 coordinates in y direction
+                lon      - scalar or 1/2D np.ndarray, WGS 84 coordinates in x direction
+    """
+
+    zone_num = int(meta['UTM_ZONE'][:-1])
+    northern = meta['UTM_ZONE'][-1].upper() == 'N'
+    # set 'strict=False' to allow coordinates outside the range of a typical single UTM zone,
+    # which can be common for large area analysis, e.g. the Norwegian mapping authority
+    # publishes a height data in UTM zone 33 coordinates for the whole country, even though
+    # most of it is technically outside zone 33.
+    lat, lon = utm.to_latlon(easting, northing, zone_num, northern=northern, strict=False)
+    return lat, lon
+
+
+def wrap(data, wrap_range=[-1.0 * np.pi, np.pi]):
+    """Wrap data into a range.
+    Parameters: data_in    : np.array, array to be wrapped
+                wrap_range : list of 2 float, range to be wrapped into
+    Returns:    data       : np.array, data after wrapping
+    """
+    w0, w1 = wrap_range
+    data = w0 + np.mod(data - w0, w1 - w0)
+    return data
+
+
+def get_metadata(dataset):
+    keys = list(dataset.coords.keys())
+    hyp3_meta = {}
+    for key in keys:
+        if key in ['time', 'x', 'y', 'band']:
+            continue
+
+        value = dataset.coords[key].values
+        if value.shape == ():
+            value = value.item()
+        else:
+            value = list(value)
+
+        hyp3_meta[key] = value
+
+    # Add geospatial metadata
+    meta = {}
+    n_dates, n_bands, meta['LENGTH'], meta['WIDTH'] = dataset.shape
+    example_image = dataset.isel(time=0)
+    meta['X_FIRST'] = dataset.coords['x'].to_numpy()[0]
+    meta['Y_FIRST'] = dataset.coords['y'].to_numpy()[0]
+    meta['X_STEP'], _, _, _, meta['Y_STEP'], *_ = dataset.attrs['transform']
+    meta['DATA_TYPE'] = example_image['data_type'].values.item()
+    meta['EPSG'] = example_image['epsg'].values.item()
+    meta['X_UNIT'] = 'meters'
+    meta['Y_UNIT'] = 'meters'
+    meta['NoDataValue'] = example_image['nodata'].values.item()
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(meta['EPSG'])
+    meta['UTM_ZONE'] = srs.GetName().split(' ')[-1]
+
+    # add universal hyp3 metadata
+    meta['PROCESSOR'] = 'hyp3'
+    meta['ALOOKS'] = hyp3_meta['azimuth_looks']
+    meta['RLOOKS'] = hyp3_meta['range_looks']
+    meta['EARTH_RADIUS'] = np.mean(hyp3_meta['earth_radius_at_nadir'])
+    meta['HEIGHT'] = np.mean(hyp3_meta['spacecraft_height'])
+    meta['STARTING_RANGE'] = np.mean(hyp3_meta['slant_range_near'])
+    meta['CENTER_LINE_UTC'] = np.mean(hyp3_meta['utc_time'])
+    meta['HEADING'] = np.mean(hyp3_meta['heading']) % 360.0 - 360.0  # ensure negative value for the heading angle
+
+    # add LAT/LON_REF1/2/3/4 based on whether satellite ascending or descending
+    N = float(meta['Y_FIRST'])
+    W = float(meta['X_FIRST'])
+    S = N + float(meta['Y_STEP']) * int(meta['LENGTH'])
+    E = W + float(meta['X_STEP']) * int(meta['WIDTH'])
+
+    # convert UTM to lat/lon
+    N, W = utm2latlon(meta, W, N)
+    S, E = utm2latlon(meta, E, S)
+
+    meta['ORBIT_DIRECTION'] = hyp3_meta['reference_orbit_direction'].upper()
+    if meta['ORBIT_DIRECTION'] == 'ASCENDING':
+        meta['LAT_REF1'] = str(S)
+        meta['LAT_REF2'] = str(S)
+        meta['LAT_REF3'] = str(N)
+        meta['LAT_REF4'] = str(N)
+        meta['LON_REF1'] = str(W)
+        meta['LON_REF2'] = str(E)
+        meta['LON_REF3'] = str(W)
+        meta['LON_REF4'] = str(E)
+    else:
+        meta['LAT_REF1'] = str(N)
+        meta['LAT_REF2'] = str(N)
+        meta['LAT_REF3'] = str(S)
+        meta['LAT_REF4'] = str(S)
+        meta['LON_REF1'] = str(E)
+        meta['LON_REF2'] = str(W)
+        meta['LON_REF3'] = str(E)
+        meta['LON_REF4'] = str(W)
+
+    if hyp3_meta['reference_granule'][0].startswith('S1'):
+        meta['PLATFORM'] = 'Sen'
+        meta['ANTENNA_SIDE'] = -1
+        meta['WAVELENGTH'] = SPEED_OF_LIGHT / SENTINEL1['carrier_frequency']
+        meta['RANGE_PIXEL_SIZE'] = SENTINEL1['range_pixel_size'] * int(meta['RLOOKS'])
+        meta['AZIMUTH_PIXEL_SIZE'] = SENTINEL1['azimuth_pixel_size'] * int(meta['ALOOKS'])
+    else:
+        raise NotImplementedError('Only Sentinel-1 data is currently supported')
+
+    date1s = [dt.datetime.fromisoformat(x).strftime('%Y%m%d') for x in hyp3_meta['start_datetime']]
+    date2s = [dt.datetime.fromisoformat(x).strftime('%Y%m%d') for x in hyp3_meta['end_datetime']]
+    date12s = [f'{d1}_{d2}' for d1, d2 in zip(date1s, date2s)]
+
+    perp_baseline = np.abs(hyp3_meta['baseline'])
+    return meta, date12s, perp_baseline
+
+
+def write_ifgram_stack(outfile, dataset, metadata, date12s, perp_baselines):
+    stack_dataset_names = {'unw_phase': 'unwrapPhase', 'corr': 'coherence'}
+    has_conncomp = 'conncomp' in list(dataset.coords['band'].to_numpy())
+    if has_conncomp:
+        stack_dataset_names['conncomp'] = 'connectComponent'
+    dataset.attrs = {}
+
+    new_dataset = xr.Dataset()
+    for name in stack_dataset_names:
+        new_name = stack_dataset_names[name]
+        new_dataset[new_name] = dataset.sel(band=name).astype(np.float32)
+        new_dataset[new_name].attrs['MODIFICATION_TIME'] = str(time.time())
+
+    new_dataset = new_dataset.drop_vars(list(dataset.coords))
+    new_dataset['dropIfgram'] = np.ones(new_dataset['unwrapPhase'].shape[0], dtype=np.bool_)
+    new_dataset['bperp'] = perp_baselines
+
+    date1 = np.array([d1.split('_')[0].encode('utf-8') for d1 in date12s])
+    date2 = np.array([d2.split('_')[1].encode('utf-8') for d2 in date12s])
+    new_dataset['date'] = (('date12', 'pair'), np.array((date1, date2)).astype(np.unicode_).T)
+
+    for key, value in metadata.items():
+        new_dataset.attrs[key] = str(value)
+    new_dataset.to_netcdf(outfile, format='NETCDF4', mode='w')
+
+
+def write_geometry(outfile, dataset, metadata):
+    first_product = dataset.isel(time=0)
+    first_product.attrs = {}
+
+    # Convert from hyp3/gamma to mintpy/isce2 convention
+    incidence_angle = first_product.sel(band='lv_theta')
+    # incidence_angle[incidence_angle == 0] = np.nan
+    incidence_angle = 90 - (incidence_angle * 180 / np.pi)
+
+    # Calculate Slant Range distance
+    slant_range_distance = incidence_angle2slant_range_distance(metadata, incidence_angle)
+
+    # Convert from hyp3/gamma to mintpy/isce2 convention
+    azimuth_angle = first_product.sel(band='lv_phi')
+    # azimuth_angle[azimuth_angle == 0] = np.nan
+    azimuth_angle = azimuth_angle * 180 / np.pi - 90  # hyp3/gamma to mintpy/isce2 convention
+    azimuth_angle = wrap(azimuth_angle, wrap_range=[-180, 180])  # rewrap within -180 to 180
+    bands = {
+        'height': first_product.sel(band='dem'),
+        'incidenceAngle': incidence_angle,
+        'slantRangeDistance': slant_range_distance,
+        'azimuthAngle': azimuth_angle,
+        'waterMask': first_product.sel(band='water_mask'),
+    }
+    new_dataset = xr.Dataset()
+    for name in bands:
+        dtype = np.bool_ if name == 'water_mask' else np.float32
+        new_dataset[name] = bands[name].astype(dtype)
+        new_dataset[name].attrs['MODIFICATION_TIME'] = str(time.time())
+
+    new_dataset = new_dataset.drop_vars(list(dataset.coords))
+    for key, value in metadata.items():
+        new_dataset.attrs[key] = str(value)
+    new_dataset.to_netcdf(outfile, format='NETCDF4', mode='w')
+
+
+def create_mintpy_inputs(
+    stac_file,
+    subset_yx=None,
+    subset_geo=None,
+    compression=None,
+    ifg_outfile='./inputs/ifgramStack.h5',
+    geom_outfile='./inputs/geometryGeo.h5',
+    chunksize='5 MB',
+):
+    collection = pystac.Collection.from_file(stac_file)
+    items = list(collection.get_all_items())
+    dataset = stackstac.stack(items, chunksize=chunksize, fill_value=0)
+
+    if subset_geo and subset_yx:
+        print('Both geographic and index subsets were provided. Using geographic subset method.')
+
+    if subset_geo:
+        dataset = dataset.sel(y=slice(subset_geo[1], subset_geo[0]), x=slice(subset_geo[2], subset_geo[3]))
+    elif subset_yx:
+        dataset = dataset.isel(y=slice(subset_yx[0], subset_yx[1]), x=slice(subset_yx[2], subset_yx[3]))
+
+    meta, date12s, perp_baselines = get_metadata(dataset)
+
+    meta['FILE_TYPE'] = 'ifgramStack'
+    write_ifgram_stack(ifg_outfile, dataset, meta, date12s, perp_baselines)
+
+    meta['FILE_TYPE'] = 'geometry'
+    write_geometry(geom_outfile, dataset, meta)
+
+
+if __name__ == '__main__':
+    create_mintpy_inputs('./stac/collection.json', subset_geo=[3903739, 3992303, 403177, 498368])

--- a/src/hyp3_sdk/stac.py
+++ b/src/hyp3_sdk/stac.py
@@ -31,7 +31,10 @@ HYP3_PROVIDER = pystac.Provider(
     url='https://hyp3-docs.asf.alaska.edu/',
     extra_fields={'processing:level': 'L3', 'processing:lineage': 'ASF DAAC HyP3 2023'},
 )
-SENTINEL_DATA_DESCRIPTION = 'HyP3 genereted Sentinel-1 SAR products and their associated files. The source data for these products are Sentinel-1 Single Look Complex (SLC) products processed by ESA'
+SENTINEL_DATA_DESCRIPTION = (
+    'HyP3 genereted Sentinel-1 SAR products and their associated files.'
+    ' The source data for these products are Sentinel-1 Single Look Complex (SLC) products processed by ESA'
+)
 
 RTC_PRODUCTS = ['rgb', 'area', 'dem', 'inc_map', 'ls_map']
 
@@ -217,7 +220,7 @@ def get_epsg(geo_key_list: Iterable[int]) -> int:
         The EPSG code for the projected coordinate system
     """
     projected_crs_key_id = 3072
-    geo_keys = [geo_key_list[i : i + 4] for i in range(0, len(geo_key_list), 4)]
+    geo_keys = [geo_key_list[i: i + 4] for i in range(0, len(geo_key_list), 4)]
     for key in geo_keys:
         if key[0] == projected_crs_key_id:
             return int(key[3])

--- a/src/hyp3_sdk/stac.py
+++ b/src/hyp3_sdk/stac.py
@@ -13,6 +13,7 @@ from pystac import Extent, ProviderRole, SpatialExtent, Summaries, TemporalExten
 from pystac.extensions import sar
 from pystac.extensions.projection import ProjectionExtension
 from pystac.extensions.raster import RasterExtension
+from pystac.extensions.sar import SarExtension
 from tqdm import tqdm
 
 from hyp3_sdk import Batch, Job
@@ -318,8 +319,8 @@ def create_stac_item(job: Job) -> pystac.Item:
     pattern = '%Y%m%dT%H%M%S'
     start_time = datetime.strptime(param_file.reference_granule.split('_')[3], pattern).replace(tzinfo=timezone.utc)
     stop_time = datetime.strptime(param_file.secondary_granule.split('_')[3], pattern).replace(tzinfo=timezone.utc)
-    reference_polarization = param_file.reference_granule.split('_')[5]
-    secondary_polarization = param_file.secondary_granule.split('_')[5]
+    reference_polarization = param_file.reference_granule.split('_')[4]
+    secondary_polarization = param_file.secondary_granule.split('_')[4]
     polarizations = list(set([reference_polarization, secondary_polarization]))
 
     # If you're using GDAL to get the geotiff info, you can use this code
@@ -353,7 +354,7 @@ def create_stac_item(job: Job) -> pystac.Item:
             RasterExtension.get_schema_uri(),
             ProjectionExtension.get_schema_uri(),
             # TODO can't get this schema to validate for now
-            # SarExtension.get_schema_uri(),
+            SarExtension.get_schema_uri(),
         ],
     )
     for asset_type in INSAR_ISCE_BURST_PRODUCTS:

--- a/src/hyp3_sdk/stac.py
+++ b/src/hyp3_sdk/stac.py
@@ -230,7 +230,7 @@ def get_epsg(geo_key_list: Iterable[int]) -> int:
         The EPSG code for the projected coordinate system
     """
     projected_crs_key_id = 3072
-    geo_keys = [geo_key_list[i : i + 4] for i in range(0, len(geo_key_list), 4)]
+    geo_keys = [geo_key_list[i: i + 4] for i in range(0, len(geo_key_list), 4)]
     for key in geo_keys:
         if key[0] == projected_crs_key_id:
             return int(key[3])

--- a/src/hyp3_sdk/stac.py
+++ b/src/hyp3_sdk/stac.py
@@ -1,4 +1,5 @@
 """A module for creating STAC collections based on HyP3-SDK Batch/Job objects"""
+import json
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -220,7 +221,7 @@ def get_epsg(geo_key_list: Iterable[int]) -> int:
         The EPSG code for the projected coordinate system
     """
     projected_crs_key_id = 3072
-    geo_keys = [geo_key_list[i: i + 4] for i in range(0, len(geo_key_list), 4)]
+    geo_keys = [geo_key_list[i : i + 4] for i in range(0, len(geo_key_list), 4)]
     for key in geo_keys:
         if key[0] == projected_crs_key_id:
             return int(key[3])
@@ -318,6 +319,12 @@ def validate_stack(batch: Batch) -> None:
     param_set = list(set([str(job) for job in job_params]))
     if len(param_set) != 1:
         raise ValueError('Not all jobs have the same processing parameters')
+
+
+def write_item(item):
+    item_dict = item.to_dict(include_self_link=False, transform_hrefs=False)
+    with open(f'{item.id}.json', 'w') as f:
+        f.write(json.dumps(item_dict))
 
 
 def create_insar_stac_item(job: Job, geo_info: GeoInfo, param_file: ParameterFile) -> pystac.Item:

--- a/src/hyp3_sdk/stac.py
+++ b/src/hyp3_sdk/stac.py
@@ -326,7 +326,6 @@ def create_stac_item(job: Job) -> pystac.Item:
     # unw_file_url = '/vsicurl/' + base_url.replace('.zip', '_unw_phase.tif')
     # geotransform, shape, epsg = get_geotiff_info(unw_file_url)
 
-
     image_properties = {
         'data_type': 'float32',
         'nodata': 0,
@@ -382,7 +381,7 @@ def create_stac_item(job: Job) -> pystac.Item:
     return item
 
 
-def create_stac_catalog(batch: Batch, out_path: Path, id: str = 'hyp3_jobs') -> None:
+def create_stac_collection(batch: Batch, out_path: Path, collection_id: str = 'hyp3_jobs') -> None:
     """Create a STAC collection from a HyP3 batch and save it to a directory
 
     Args:
@@ -403,7 +402,7 @@ def create_stac_catalog(batch: Batch, out_path: Path, id: str = 'hyp3_jobs') -> 
     summary_dict = {'constellation': [SENTINEL_CONSTELLATION], 'platform': SENTINEL_PLATFORMS}
 
     collection = pystac.Collection(
-        id=id,
+        id=collection_id,
         description=SENTINEL_BURST_DESCRIPTION,
         extent=extent,
         keywords=['sentinel', 'copernicus', 'esa', 'sar'],

--- a/src/hyp3_sdk/stac.py
+++ b/src/hyp3_sdk/stac.py
@@ -1,0 +1,262 @@
+import json
+import struct
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import fsspec
+import pystac
+from osgeo import gdal
+from shapely import geometry, to_geojson
+from tqdm import tqdm
+
+
+gdal.UseExceptions()
+
+COLLECTION_ID = 'sentinel-1-hyp3-product-stack'
+SAR_INSTRUMENT_MODE = 'IW'
+SAR_FREQUENCY_BAND = 'C'
+
+INSAR_ISCE_BURST_PRODUCTS = [
+    'conncomp',
+    'corr',
+    'unw_phase',
+    'wrapped_phase',
+    'lv_phi',
+    'lv_theta',
+    'dem',
+    'water_mask',
+]
+
+
+@dataclass
+class ParameterFile:
+    reference_granule: str
+    secondary_granule: str
+    reference_orbit_direction: str
+    reference_orbit_number: str
+    secondary_orbit_direction: str
+    secondary_orbit_number: str
+    baseline: float
+    utc_time: float
+    heading: float
+    spacecraft_height: float
+    earth_radius_at_nadir: float
+    slant_range_near: float
+    slant_range_center: float
+    slant_range_far: float
+    range_looks: int
+    azimuth_looks: int
+    insar_phase_filter: bool
+    phase_filter_parameter: float
+    range_bandpass_filter: bool
+    azimuth_bandpass_filter: bool
+    dem_source: str
+    dem_resolution: int
+    unwrapping_type: str
+    speckle_filter: bool
+    water_mask: bool
+
+    def __str__(self):
+        output_strings = [
+            f'Reference Granule: {self.reference_granule}\n',
+            f'Secondary Granule: {self.secondary_granule}\n',
+            f'Reference Pass Direction: {self.reference_orbit_direction}\n',
+            f'Reference Orbit Number: {self.reference_orbit_number}\n',
+            f'Secondary Pass Direction: {self.secondary_orbit_direction}\n',
+            f'Secondary Orbit Number: {self.secondary_orbit_number}\n',
+            f'Baseline: {self.baseline}\n',
+            f'UTC time: {self.utc_time}\n',
+            f'Heading: {self.heading}\n',
+            f'Spacecraft height: {self.spacecraft_height}\n',
+            f'Earth radius at nadir: {self.earth_radius_at_nadir}\n',
+            f'Slant range near: {self.slant_range_near}\n',
+            f'Slant range center: {self.slant_range_center}\n',
+            f'Slant range far: {self.slant_range_far}\n',
+            f'Range looks: {self.range_looks}\n',
+            f'Azimuth looks: {self.azimuth_looks}\n',
+            f'INSAR phase filter: {"yes" if self.insar_phase_filter else "no"}\n',
+            f'Phase filter parameter: {self.phase_filter_parameter}\n',
+            f'Range bandpass filter: {"yes" if self.range_bandpass_filter else "no"}\n',
+            f'Azimuth bandpass filter: {"yes" if self.azimuth_bandpass_filter else "no"}\n',
+            f'DEM source: {self.dem_source}\n',
+            f'DEM resolution (m): {self.dem_resolution}\n',
+            f'Unwrapping type: {self.unwrapping_type}\n',
+            f'Speckle filter: {"yes" if self.speckle_filter else "no"}\n',
+            f'Water mask: {"yes" if self.water_mask else "no"}\n',
+        ]
+
+        return ''.join(output_strings)
+
+    def __repr__(self):
+        return self.__str__()
+
+    def write(self, out_path: Path):
+        out_path.write_text(self.__str__())
+
+    @staticmethod
+    def read(file_path: Path, base_fs=None):
+        file_path = str(file_path)
+        if file_path.startswith('https'):
+            if base_fs is None:
+                base_fs = fsspec.filesystem('https', block_size=5 * (2**20))
+        else:
+            base_fs = fsspec.filesystem('file')
+
+        with base_fs.open(file_path, 'r') as file:
+            text = file.read().strip()
+
+        parameters = {}
+        for line in text.split('\n'):
+            key, *values = line.strip().split(':')
+            value = values[0].replace(' ', '')
+            parameters[key] = value
+
+        param_file = ParameterFile(
+            reference_granule=parameters['Reference Granule'],
+            secondary_granule=parameters['Secondary Granule'],
+            reference_orbit_direction=parameters['Reference Pass Direction'],
+            reference_orbit_number=parameters['Reference Orbit Number'],
+            secondary_orbit_direction=parameters['Secondary Pass Direction'],
+            secondary_orbit_number=parameters['Secondary Orbit Number'],
+            baseline=float(parameters['Baseline']),
+            utc_time=float(parameters['UTC time']),
+            heading=float(parameters['Heading']),
+            spacecraft_height=float(parameters['Spacecraft height']),
+            earth_radius_at_nadir=float(parameters['Earth radius at nadir']),
+            slant_range_near=float(parameters['Slant range near']),
+            slant_range_center=float(parameters['Slant range center']),
+            slant_range_far=float(parameters['Slant range far']),
+            range_looks=int(parameters['Range looks']),
+            azimuth_looks=int(parameters['Azimuth looks']),
+            insar_phase_filter=parameters['INSAR phase filter'] == 'yes',
+            phase_filter_parameter=float(parameters['Phase filter parameter']),
+            range_bandpass_filter=parameters['Range bandpass filter'] == 'yes',
+            azimuth_bandpass_filter=parameters['Azimuth bandpass filter'] == 'yes',
+            dem_source=parameters['DEM source'],
+            dem_resolution=int(parameters['DEM resolution (m)']),
+            unwrapping_type=parameters['Unwrapping type'],
+            speckle_filter=parameters['Speckle filter'] == 'yes',
+            water_mask=True,
+        )
+
+        return param_file
+
+
+def jsonify_stac_item(stac_item: dict) -> str:
+    class DateTimeEncoder(json.JSONEncoder):
+        def default(self, obj):
+            if isinstance(obj, datetime) and obj.tzinfo == timezone.utc:
+                return obj.isoformat().removesuffix('+00:00') + 'Z'
+            return json.JSONEncoder.default(self, obj)
+
+    return json.dumps(stac_item, cls=DateTimeEncoder)
+
+
+def get_geotiff_bounding_box_no_gdal(file_path):
+    with open(file_path, 'rb') as tiff_file:
+        # Read the TIFF header to get the offset to the first IFD (Image File Directory)
+        header = tiff_file.read(8)
+        (magic_number,) = struct.unpack('HHHH', header)
+        if magic_number != 0x4949 and magic_number != 0x4D4D:
+            raise ValueError('Not a valid TIFF file.')
+
+        if magic_number == 0x4949:  # Little-endian
+            byte_order = '<'
+        else:  # Big-endian
+            byte_order = '>'
+
+        (offset_to_ifd,) = struct.unpack(byte_order + 'I', tiff_file.read(4))
+
+        # Move to the offset of the first IFD
+        tiff_file.seek(offset_to_ifd)
+
+        # Read the number of directory entries
+        (num_entries,) = struct.unpack(byte_order + 'H', tiff_file.read(2))
+
+        for _ in range(num_entries):
+            tag, field_type, num_values, value_offset = struct.unpack(byte_order + 'HHII', tiff_file.read(12))
+
+            # GeoKeyDirectoryTag (34735) contains the geo-referencing information
+            if tag == 34735:
+                tiff_file.seek(value_offset)
+                geo_keys = struct.unpack(byte_order + 'I' * num_values, tiff_file.read(4 * num_values))
+
+                min_x = geo_keys[10]  # GeoKeyDirectoryTag: ModelTiepointTag
+                min_y = geo_keys[11]  # GeoKeyDirectoryTag: ModelTiepointTag
+                max_x = min_x + geo_keys[4] * geo_keys[1]  # width * pixel scale in x direction
+                max_y = min_y + geo_keys[5] * geo_keys[0]  # height * pixel scale in y direction
+
+                return min_x, min_y, max_x, max_y
+
+        raise ValueError('GeoTIFF metadata not found.')
+
+
+def get_geotiff_info(file_path):
+    dataset = gdal.Open(file_path)
+    geotransform = dataset.GetGeoTransform()
+    shape = (dataset.RasterXSize, dataset.RasterYSize)
+    proj = dataset.GetProjectionRef()
+    dataset = None
+    return geotransform, shape, proj
+
+
+def get_bounding_box(geotransform, shape):
+    min_x = geotransform[0]
+    max_x = min_x + geotransform[1] * shape[0]
+    max_y = geotransform[3]
+    min_y = max_y + geotransform[5] * shape[1]
+
+    bbox = geometry.box(min_x, min_y, max_x, max_y)
+    return bbox
+
+
+def create_stac_item(product) -> dict:
+    base_url = product.to_dict()['files'][0]['url']
+    param_file_url = base_url.replace('.zip', '.txt')
+    param_file = ParameterFile.read(param_file_url)
+    pattern = '%Y%m%dT%H%M%S'
+    start_time = datetime.strptime(param_file.reference_granule.split('_')[3], pattern).replace(tzinfo=timezone.utc)
+    stop_time = datetime.strptime(param_file.secondary_granule.split('_')[3], pattern).replace(tzinfo=timezone.utc)
+    reference_polarization = param_file.reference_granule.split('_')[5]
+    secondary_polarization = param_file.secondary_granule.split('_')[5]
+    polarizations = list(set([reference_polarization, secondary_polarization]))
+
+    unw_file_url = '/vsicurl/' + base_url.replace('.zip', '_unw_phase.tif')
+    geotransform, shape, proj = get_geotiff_info(unw_file_url)
+    bbox = get_bounding_box(geotransform, shape)
+
+    properties = {
+        'sar:instrument_mode': SAR_INSTRUMENT_MODE,
+        'sar:frequency_band': SAR_FREQUENCY_BAND,
+        'sar:product_type': product.to_dict()['job_type'],
+        'sar:polarizations': polarizations,
+        'start_datetime': start_time.isoformat(),
+        'end_datetime': stop_time.isoformat(),
+    }
+    properties.update(param_file.__dict__)
+    item = pystac.Item(
+        id=base_url.split('/')[-1].replace('.zip', ''),
+        geometry=to_geojson(bbox),
+        bbox=to_geojson(bbox),
+        datetime=start_time,
+        properties=properties,
+        stac_extensions=['https://stac-extensions.github.io/sar/v1.0.0/schema.json'],
+    )
+    for asset_type in INSAR_ISCE_BURST_PRODUCTS:
+        item.add_asset(
+            key=asset_type,
+            asset=pystac.Asset(
+                href=base_url.replace('.zip', f'_{asset_type}.tif'), media_type=pystac.MediaType.GEOTIFF
+            ),
+        )
+    return item
+
+
+def create_stac_catalog(products, out_path, id='hyp3_jobs'):
+    catalog = pystac.Catalog(id=id, description='A catalog of Hyp3 jobs')
+    for product in tqdm(products):
+        item = create_stac_item(product)
+        catalog.add_item(item)
+    catalog.normalize_hrefs(str(out_path))
+    catalog.save(catalog_type=pystac.CatalogType.SELF_CONTAINED)

--- a/src/hyp3_sdk/stac.py
+++ b/src/hyp3_sdk/stac.py
@@ -327,14 +327,12 @@ def create_stac_item(job: Job) -> pystac.Item:
     # unw_file_url = '/vsicurl/' + base_url.replace('.zip', '_unw_phase.tif')
     # geotransform, shape, epsg = get_geotiff_info(unw_file_url)
 
-    image_properties = {
+    properties = {
         'data_type': 'float32',
         'nodata': 0,
         'proj:shape': shape,
         'proj:transform': geotransform,
         'proj:epsg': epsg,
-    }
-    properties = {
         'sar:instrument_mode': 'IW',
         'sar:frequency_band': sar.FrequencyBand.C,
         'sar:product_type': job.to_dict()['job_type'],
@@ -342,7 +340,6 @@ def create_stac_item(job: Job) -> pystac.Item:
         'start_datetime': start_time.isoformat(),
         'end_datetime': stop_time.isoformat(),
     }
-    properties.update(image_properties)
     properties.update(param_file.__dict__)
     item = pystac.Item(
         id=base_url.split('/')[-1].replace('.zip', ''),
@@ -353,7 +350,6 @@ def create_stac_item(job: Job) -> pystac.Item:
         stac_extensions=[
             RasterExtension.get_schema_uri(),
             ProjectionExtension.get_schema_uri(),
-            # TODO can't get this schema to validate for now
             SarExtension.get_schema_uri(),
         ],
     )

--- a/src/hyp3_sdk/stac.py
+++ b/src/hyp3_sdk/stac.py
@@ -384,7 +384,7 @@ def create_insar_stac_item(job: Job, geo_info: GeoInfo, param_file: ParameterFil
         key='thumbnail',
         asset=pystac.Asset(href=thumbnail, media_type=pystac.MediaType.PNG, roles=['thumbnail']),
     )
-    item.validate()
+    # item.validate()
     return item
 
 
@@ -547,5 +547,5 @@ def create_stac_collection(batch: Batch, out_path: Path, collection_id: str = 'h
     )
     [collection.add_item(item) for item in items]
     collection.normalize_hrefs(str(out_path))
-    collection.validate()
+    # collection.validate()
     collection.save(catalog_type=pystac.CatalogType.SELF_CONTAINED)

--- a/src/hyp3_sdk/stac.py
+++ b/src/hyp3_sdk/stac.py
@@ -1,4 +1,4 @@
-"""A module for creating STAC collections based on HyP3-SDK Product objects"""
+"""A module for creating STAC collections based on HyP3-SDK Batch/Job objects"""
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone

--- a/src/hyp3_sdk/stac.py
+++ b/src/hyp3_sdk/stac.py
@@ -310,6 +310,11 @@ def create_stac_item(job: Job) -> pystac.Item:
     base_url = job.to_dict()['files'][0]['url']
     param_file_url = base_url.replace('.zip', '.txt')
     param_file = ParameterFile.read(param_file_url)
+
+    unw_file_url = base_url.replace('.zip', '_unw_phase.tif')
+    geotransform, shape, epsg = get_geotiff_info_nogdal(unw_file_url)
+    bbox = get_bounding_box(geotransform, shape)
+
     pattern = '%Y%m%dT%H%M%S'
     start_time = datetime.strptime(param_file.reference_granule.split('_')[3], pattern).replace(tzinfo=timezone.utc)
     stop_time = datetime.strptime(param_file.secondary_granule.split('_')[3], pattern).replace(tzinfo=timezone.utc)
@@ -321,9 +326,6 @@ def create_stac_item(job: Job) -> pystac.Item:
     # unw_file_url = '/vsicurl/' + base_url.replace('.zip', '_unw_phase.tif')
     # geotransform, shape, epsg = get_geotiff_info(unw_file_url)
 
-    unw_file_url = base_url.replace('.zip', '_unw_phase.tif')
-    geotransform, shape, epsg = get_geotiff_info_nogdal(unw_file_url)
-    bbox = get_bounding_box(geotransform, shape)
 
     image_properties = {
         'data_type': 'float32',

--- a/src/hyp3_sdk/stac.py
+++ b/src/hyp3_sdk/stac.py
@@ -358,6 +358,7 @@ def create_insar_stac_item(job: Job, geo_info: GeoInfo, param_file: ParameterFil
     stop_time = datetime.strptime(param_file.secondary_granule.split('_')[date_loc], pattern).replace(
         tzinfo=timezone.utc
     )
+    mid_time = datetime.fromtimestamp((start_time.timestamp() + stop_time.timestamp()) / 2).replace(tzinfo=timezone.utc)
     polarizations = list(set([reference_polarization, secondary_polarization]))
 
     extra_properies = {
@@ -368,7 +369,7 @@ def create_insar_stac_item(job: Job, geo_info: GeoInfo, param_file: ParameterFil
     }
     extra_properies.update(param_file.__dict__)
 
-    item = create_item(base_url, start_time, geo_info, insar_products, extra_properies)
+    item = create_item(base_url, mid_time, geo_info, insar_products, extra_properies)
     thumbnail = base_url.replace('.zip', '_unw_phase.png')
     item.add_asset(
         key='thumbnail',

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 import numpy as np
 import pytest
 import tifffile
+
 from hyp3_sdk import Job, stac
 
 

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1,0 +1,65 @@
+"""Tests for the stac module"""
+from hyp3_sdk import stac
+
+
+def test_parameter_file(tmp_path):
+    """Test the ParameterFile class"""
+    param_file = stac.ParameterFile(
+        reference_granule='foo',
+        secondary_granule='bar',
+        reference_orbit_direction='ASCENDING',
+        reference_orbit_number=123,
+        secondary_orbit_direction='DESCENDING',
+        secondary_orbit_number=124,
+        baseline=100.0,
+        utc_time=1546344000.0,
+        heading=0.0,
+        spacecraft_height=700000.0,
+        earth_radius_at_nadir=6371000.0,
+        slant_range_near=800000.0,
+        slant_range_center=850000.0,
+        slant_range_far=900000.0,
+        range_looks=5,
+        azimuth_looks=5,
+        insar_phase_filter=True,
+        phase_filter_parameter=0.2,
+        range_bandpass_filter=True,
+        azimuth_bandpass_filter=True,
+        dem_source='baz',
+        dem_resolution=30,
+        unwrapping_type='SNAPHU',
+        speckle_filter=True,
+        water_mask=True,
+    )
+
+    assert str(param_file).startswith('Reference Granule: foo\n')
+    assert str(param_file).endswith('Water mask: yes\n')
+
+    param_file.write(tmp_path / 'test.txt')
+    assert (tmp_path / 'test.txt').read_text() == str(param_file)
+    loaded_param_file = stac.ParameterFile.read(tmp_path / 'test.txt')
+    assert loaded_param_file == param_file
+
+
+def test_geoinfo():
+    """Test the GeoInfo class"""
+    geo_info = stac.GeoInfo(
+        transform=[1, 2, 3, 4, 5, 6],
+        shape=[7, 8],
+        epsg=9,
+    )
+
+    assert geo_info.bbox == [1, 46, 17, 4]
+    assert geo_info.bbox_geojson == {
+        'type': 'Polygon',
+        'coordinates': [
+            [
+                [1, 6],
+                [7, 6],
+                [7, 4],
+                [1, 4],
+                [1, 6],
+            ]
+        ],
+    }
+    assert geo_info.proj_transform == [2, 3, 1, 6, 5, 4, 0, 0, 1]


### PR DESCRIPTION
Adapted from and heavily inspired by @scottyhq 's 2023 AGU presentation, this PR adds the ability to create STAC items and collections from sets of completed HyP3 jobs. While we do provide unzipped copies of HyP3 products, we have never publicized this well because there has not been an efficient method to retrieve them. The STAC ecosystem provides an elegant solution to this problem that the community is already familiar with. 

In addition, it provides utilities for turning these STAC collection into Xarray datastacks using `odc-stac`, and for turning these Xarray objects into MintPy-compatible hdf5 files. Using this new functionality to prep HyP3 data for MintPy is a significant improvement over our current preparation guidelines, since it removes the need to download, unzip, and crop each product individually.

To demo the new MintPy workflow enabled by these changes, check out this [modified version of our HyP3 MintPy notebook](docs/tutorials/hyp3_insar_stack_for_ts_analysis.ipynb).