### PR TITLE
Switch to using reference/secondary for insar_isce_burst_job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [7.1.1]
 
 ### Changed
-* The `insar_isce_burst_job` so that it takes a `reference` and `secondary` scene as input, not `granule1` and `granule2`. Backward compatibility in `submit_insar_isce_burst_job` is maintained for now.
+* `insar_isce_burst_job` so that it takes a `reference` and `secondary` scene as input, rather than `granule1` and `granule2`. Backward compatibility in `submit_insar_isce_burst_job` is maintained for now, but it will be broken in the future.
 
 ## [7.0.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [8.0.0]
+## [7.1.1]
 
 ### Changed
 * The `insar_isce_burst_job` so that it takes a `reference` and `secondary` scene as input, not `granule1` and `granule2`. Backward compatibility in `submit_insar_isce_burst_job` is maintained for now.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [8.0.0]
 
 ### Changed
-* The `insar_isce_burst_job` so that it takes a `reference` and `secondary` scene as input, not `granule1` and `granule2`.
+* The `insar_isce_burst_job` so that it takes a `reference` and `secondary` scene as input, not `granule1` and `granule2`. Backward compatibility in `submit_insar_isce_burst_job` is maintained for now.
 
 ## [7.0.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.0.0]
+
+### Changed
+* The `insar_isce_burst_job` so that it takes a `reference` and `secondary` scene as input, not `granule1` and `granule2`.
+
 ## [7.0.1]
 
 ### Removed

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,6 @@ dependencies:
   - python>=3.10
   - pip
   # For packaging, and testing
-  - build
   - flake8
   - flake8-import-order
   - flake8-blind-except

--- a/src/hyp3_sdk/hyp3.py
+++ b/src/hyp3_sdk/hyp3.py
@@ -424,8 +424,11 @@ class HyP3:
         return job_dict
 
     def submit_insar_isce_burst_job(self,
-                                    reference: Union[str, Iterable[str]],
-                                    secondary: Union[str, Iterable[str]],
+                                    *args,
+                                    reference: Union[str, Iterable[str]] = None,
+                                    secondary: Union[str, Iterable[str]] = None,
+                                    granule1: Optional[str] = None,
+                                    granule2: Optional[str] = None,
                                     name: Optional[str] = None,
                                     apply_water_mask: bool = False,
                                     looks: Literal['20x4', '10x2', '5x1'] = '20x4') -> Batch:
@@ -434,6 +437,8 @@ class HyP3:
         Args:
             reference: The reference granule (older scene) to use
             secondary: The secondary granule (younger scene) to use
+            granule1: Depreceated argument superseeded by reference
+            granule2: Depreceated argument superseeded by secondary
             name: A name for the job
             apply_water_mask: Sets pixels over coastal waters and large inland waterbodies
                 as invalid for phase unwrapping
@@ -444,6 +449,24 @@ class HyP3:
         """
         arguments = locals().copy()
         arguments.pop('self')
+        arguments.pop('args')
+        
+        if len(args) == 2:
+            warnings.warn("Positional arguments for submit_insar_isce_burst_job are now mapped to 'reference' and 'secondary'.", DeprecationWarning)
+            arguments['reference'] = args[0]
+            arguments['secondary'] = args[1]
+
+        if arguments['granule1']:
+            warnings.warn("Keyword argument 'granule1' is deprecated. Use 'reference' instead.", DeprecationWarning)
+            arguments['reference'] = arguments['granule1']
+
+        if arguments['granule2']:
+            warnings.warn("Keyword argument 'granule2' is deprecated. Use 'secondary' instead.", DeprecationWarning)
+            arguments['secondary'] = arguments['granule1']
+
+        arguments.pop('granule1')
+        arguments.pop('granule2')
+
         job_dict = self.prepare_insar_isce_burst_job(**arguments)
         return self.submit_prepared_jobs(prepared_jobs=job_dict)
 

--- a/src/hyp3_sdk/hyp3.py
+++ b/src/hyp3_sdk/hyp3.py
@@ -450,9 +450,8 @@ class HyP3:
         arguments = locals().copy()
         arguments.pop('self')
         arguments.pop('args')
-        
+
         if len(args) == 2:
-            warnings.warn("Positional arguments for submit_insar_isce_burst_job are now mapped to 'reference' and 'secondary'.", DeprecationWarning)
             arguments['reference'] = args[0]
             arguments['secondary'] = args[1]
 

--- a/src/hyp3_sdk/hyp3.py
+++ b/src/hyp3_sdk/hyp3.py
@@ -4,7 +4,7 @@ import warnings
 from datetime import datetime, timezone
 from functools import singledispatchmethod
 from getpass import getpass
-from typing import List, Literal, Optional, Union
+from typing import Iterable, List, Literal, Optional, Union
 from urllib.parse import urljoin
 from warnings import warn
 
@@ -424,16 +424,16 @@ class HyP3:
         return job_dict
 
     def submit_insar_isce_burst_job(self,
-                                    granule1: str,
-                                    granule2: str,
+                                    reference: Union[str, Iterable[str]],
+                                    secondary: Union[str, Iterable[str]],
                                     name: Optional[str] = None,
                                     apply_water_mask: bool = False,
                                     looks: Literal['20x4', '10x2', '5x1'] = '20x4') -> Batch:
         """Submit an InSAR ISCE burst job.
 
         Args:
-            granule1: The first granule (scene) to use
-            granule2: The second granule (scene) to use
+            reference: The reference granule (older scene) to use
+            secondary: The secondary granule (younger scene) to use
             name: A name for the job
             apply_water_mask: Sets pixels over coastal waters and large inland waterbodies
                 as invalid for phase unwrapping
@@ -449,16 +449,16 @@ class HyP3:
 
     @classmethod
     def prepare_insar_isce_burst_job(cls,
-                                     granule1: str,
-                                     granule2: str,
+                                     reference: Union[str, Iterable[str]],
+                                     secondary: Union[str, Iterable[str]],
                                      name: Optional[str] = None,
                                      apply_water_mask: bool = False,
                                      looks: Literal['20x4', '10x2', '5x1'] = '20x4') -> dict:
         """Prepare an InSAR ISCE burst job.
 
         Args:
-            granule1: The first granule (scene) to use
-            granule2: The second granule (scene) to use
+            reference: The reference granule (older scene) to use
+            secondary: The secondary granule (younger scene) to use
             name: A name for the job
             apply_water_mask: Sets pixels over coastal waters and large inland waterbodies
                 as invalid for phase unwrapping
@@ -468,11 +468,17 @@ class HyP3:
             A dictionary containing the prepared InSAR ISCE burst job
         """
         job_parameters = locals().copy()
-        for key in ['cls', 'granule1', 'granule2', 'name']:
+        for key in ['cls', 'reference', 'secondary', 'name']:
             job_parameters.pop(key)
 
+        if isinstance(reference, str):
+            reference = [reference]
+
+        if isinstance(secondary, str):
+            secondary = [secondary]
+
         job_dict = {
-            'job_parameters': {'granules': [granule1, granule2], **job_parameters},
+            'job_parameters': {'reference': reference, 'secondary': secondary, **job_parameters},
             'job_type': 'INSAR_ISCE_BURST',
         }
         if name is not None:

--- a/src/hyp3_sdk/hyp3.py
+++ b/src/hyp3_sdk/hyp3.py
@@ -498,7 +498,6 @@ class HyP3:
         if isinstance(reference, str):
             reference = [reference]
 
-
         if isinstance(secondary, str):
             secondary = [secondary]
 

--- a/tests/test_hyp3.py
+++ b/tests/test_hyp3.py
@@ -281,23 +281,30 @@ def test_prepare_insar_job():
 
 
 def test_prepare_insar_isce_burst_job():
-    assert HyP3.prepare_insar_isce_burst_job(granule1='my_granule1', granule2='my_granule2') == {
+    assert HyP3.prepare_insar_isce_burst_job(reference='ref_granule1', secondary='sec_granule2') == {
         'job_type': 'INSAR_ISCE_BURST',
         'job_parameters': {
-            'granules': ['my_granule1', 'my_granule2'],
+            'reference': ['ref_granule1'],
+            'secondary': ['sec_granule2'],
             'apply_water_mask': False,
             'looks': '20x4',
-        }
+        },
     }
-    assert HyP3.prepare_insar_isce_burst_job(granule1='my_granule1', granule2='my_granule2', name='my_name',
-                                             apply_water_mask=True, looks='10x2') == {
+    assert HyP3.prepare_insar_isce_burst_job(
+        reference=['ref_granule1', 'ref_granule2'],
+        secondary=['sec_granule1', 'sec_granule2'],
+        name='my_name',
+        apply_water_mask=True,
+        looks='10x2',
+    ) == {
         'job_type': 'INSAR_ISCE_BURST',
         'name': 'my_name',
         'job_parameters': {
-            'granules': ['my_granule1', 'my_granule2'],
+            'reference': ['ref_granule1', 'ref_granule2'],
+            'secondary': ['sec_granule1', 'sec_granule2'],
             'apply_water_mask': True,
             'looks': '10x2',
-        }
+        },
     }
 
 

--- a/tests/test_hyp3.py
+++ b/tests/test_hyp3.py
@@ -349,7 +349,6 @@ def test_prepare_insar_isce_burst_job():
         }
 
 
-
 def test_deprecated_warning():
     with warnings.catch_warnings(record=True) as w:
         HyP3.prepare_insar_job(granule1='my_granule1', granule2='my_granule2', include_los_displacement=False)


### PR DESCRIPTION
Should be released after the updates to HyP3. Notably, I included no validation of the reference/secondary age order because HyP3 will be checking this for us. Happy to hear feedback that we want this though.