### PR TITLE
Add support for INSAR_ISCE_MULTI_BURST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,13 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
+and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [7.2.0]
+
+### Added
+* Added `HyP3.submit_insar_isce_multi_burst_job` and `HyP3.prepare_insar_isce_multi_burst_job` methods for submitting InSAR ISCE multi burst jobs to HyP3.
 
 ## [7.1.0]
 
@@ -32,13 +37,13 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [7.0.0]
 
 ### Removed
-* Support for Python 3.9 has been removed. 
+* Support for Python 3.9 has been removed.
 
 ## [6.2.0]
 
 ### Added
 * `Job.priority` attribute
-* Unapproved `hyp3-sdk` users receive an error message when connecting to `HyP3` 
+* Unapproved `hyp3-sdk` users receive an error message when connecting to `HyP3`
 
 ## [6.1.0]
 
@@ -109,7 +114,7 @@ This release accommodates changes to the HyP3 API schema introduced in HyP3 v6.0
 
 ## [2.0.0]
 ### Changed
-* Improved error messages when Earthdata user must select Study Area or accept EULA, thanks to @kevinxmorales in #170 
+* Improved error messages when Earthdata user must select Study Area or accept EULA, thanks to @kevinxmorales in #170
 ### Removed
 * The `hyp3_sdk.TESTING` constant has been removed in favor of mocking objects in unit tests.
 
@@ -207,10 +212,10 @@ This release accommodates changes to the HyP3 API schema introduced in HyP3 v6.0
   - `hyp3_sdk.HyP3_TEST` is now `hyp3_sdk.TEST_API`
 
 ## [1.2.0](https://github.com/ASFHyP3/hyp3-sdk/compare/v1.1.3...v1.2.0)
-  
+
 ### Added
 - `Job` class now has a `logs` attribute containing links to job log files
-- Added missing [container methods](https://docs.python.org/3/reference/datamodel.html#emulating-container-types) 
+- Added missing [container methods](https://docs.python.org/3/reference/datamodel.html#emulating-container-types)
   - batches are now subscriptable: `batch[0]`
   - jobs can be searched for in batches:`job in batch`
   - jobs can be deleted from batches: `del batch[0]`
@@ -224,7 +229,7 @@ This release accommodates changes to the HyP3 API schema introduced in HyP3 v6.0
 - [#92](https://github.com/ASFHyP3/hyp3-sdk/issues/92) -- `ImportError` being
   raised when showing a progress bar because `ipywidgets` may not always be
   installed when running in a Jupyter kernel
-  
+
 ## [1.1.3](https://github.com/ASFHyP3/hyp3-sdk/compare/v1.1.2...v1.1.3)
 
 ### Added
@@ -254,7 +259,7 @@ This release accommodates changes to the HyP3 API schema introduced in HyP3 v6.0
 ### Added
 - `HyP3.find_jobs` now supports filtering by `job_type`
 - `HyP3.find_jobs` now pages through truncated responses to get all requested jobs
-- `hyp3_sdk.exceptions` now includes `ServerError` for exceptions that are a result of 
+- `hyp3_sdk.exceptions` now includes `ServerError` for exceptions that are a result of
   system errors.
 
 ### Changed
@@ -291,7 +296,7 @@ This release accommodates changes to the HyP3 API schema introduced in HyP3 v6.0
   - `HyP3.prepare_rtc_job`
   - `HyP3.prepare_insar_job`
 - `HyP3.watch`, `Job.download_files`, and `Batch.download_files` now display progress bars
-    
+
 ### Changed
 - HyP3 `Job` objects provide a better string representation
   ```python
@@ -325,7 +330,7 @@ This release accommodates changes to the HyP3 API schema introduced in HyP3 v6.0
 - SDK will attach a `User-Agent` statement like `hyp3_sdk/VERSION` to all API interactions
 
 ### Changed
-- Providing a job list to `Batch.__init__()` is now optional; an empty batch will 
+- Providing a job list to `Batch.__init__()` is now optional; an empty batch will
   be created if the job list is not provided
 - `Batch.__init__()` no longer issues a warning when creating an empty batch
 - `HyP3.find_jobs()` will now issue a warning when a zero jobs were found
@@ -352,7 +357,7 @@ This release accommodates changes to the HyP3 API schema introduced in HyP3 v6.0
 - API responses now return Batch objects if multiple jobs present.
 - Job and Batch objects now have the following member functions to help with common tasks
 - API can now watch Jobs or Batches for completion
-- Jobs are no longer created then submitted, instead submission through the API is how to get Jobs 
+- Jobs are no longer created then submitted, instead submission through the API is how to get Jobs
 - hyp3-sdk has dropped support for python <= 3.7
 
 ## [0.2.2](https://github.com/ASFHyP3/hyp3-sdk/compare/v0.2.1...v0.2.2)

--- a/src/hyp3_sdk/hyp3.py
+++ b/src/hyp3_sdk/hyp3.py
@@ -441,6 +441,69 @@ class HyP3:
             job_dict['name'] = name
         return job_dict
 
+    def submit_insar_isce_multi_burst_job(
+        self,
+        reference: list[str],
+        secondary: list[str],
+        name: str | None = None,
+        apply_water_mask: bool = False,
+        looks: Literal['20x4', '10x2', '5x1'] = '20x4',
+    ) -> Batch:
+        """Submit an InSAR ISCE multi burst job.
+
+        Args:
+            reference: A list of reference granules (scenes) to use
+            secondary: A list of secondary granules (scenes) to use
+            name: A name for the job
+            apply_water_mask: Sets pixels over coastal waters and large inland waterbodies
+                as invalid for phase unwrapping
+            looks: Number of looks to take in range and azimuth
+
+        Returns:
+            A Batch object containing the InSAR ISCE multi burst job
+        """
+        arguments = locals().copy()
+        arguments.pop('self')
+        job_dict = self.prepare_insar_isce_multi_burst_job(**arguments)
+        return self.submit_prepared_jobs(prepared_jobs=job_dict)
+
+    @classmethod
+    def prepare_insar_isce_multi_burst_job(
+        cls,
+        reference: list[str],
+        secondary: list[str],
+        name: str | None = None,
+        apply_water_mask: bool = False,
+        looks: Literal['20x4', '10x2', '5x1'] = '20x4',
+    ) -> dict:
+        """Prepare an InSAR ISCE multi burst job.
+
+        Args:
+            reference: A list of reference granules (scenes) to use
+            secondary: A list of secondary granules (scenes) to use
+            name: A name for the job
+            apply_water_mask: Sets pixels over coastal waters and large inland waterbodies
+                as invalid for phase unwrapping
+            looks: Number of looks to take in range and azimuth
+
+        Returns:
+            A dictionary containing the prepared InSAR ISCE burst job
+        """
+        job_parameters = locals().copy()
+        for key in ['cls', 'name']:
+            job_parameters.pop(key)
+
+        if len(reference) != len(secondary):
+            raise ValueError('Reference and secondary must be the same length')
+
+        job_dict = {
+            'job_parameters': {**job_parameters},
+            'job_type': 'INSAR_ISCE_MULTI_BURST',
+        }
+        if name is not None:
+            job_dict['name'] = name
+        return job_dict
+
     def submit_insar_isce_burst_job(
         self,
         granule1: str,

--- a/src/hyp3_sdk/hyp3.py
+++ b/src/hyp3_sdk/hyp3.py
@@ -487,7 +487,7 @@ class HyP3:
             looks: Number of looks to take in range and azimuth
 
         Returns:
-            A dictionary containing the prepared InSAR ISCE burst job
+            A dictionary containing the prepared InSAR ISCE multi burst job
         """
         job_parameters = locals().copy()
         for key in ['cls', 'name']:

--- a/src/hyp3_sdk/hyp3.py
+++ b/src/hyp3_sdk/hyp3.py
@@ -489,12 +489,6 @@ class HyP3:
         Returns:
             A dictionary containing the prepared InSAR ISCE multi burst job
         """
-        if len(reference) < 1 or len(secondary) < 1:
-            raise ValueError('Must include at least 1 reference scene and 1 secondary scene')
-
-        if len(reference) != len(secondary):
-            raise ValueError('Reference and secondary must be the same length')
-
         job_parameters = locals().copy()
         for key in ['cls', 'name']:
             job_parameters.pop(key)

--- a/src/hyp3_sdk/hyp3.py
+++ b/src/hyp3_sdk/hyp3.py
@@ -489,6 +489,9 @@ class HyP3:
         Returns:
             A dictionary containing the prepared InSAR ISCE multi burst job
         """
+        if len(reference) < 1 or len(secondary) < 1:
+            raise ValueError('Must include at least 1 reference scene and 1 secondary scene')
+
         if len(reference) != len(secondary):
             raise ValueError('Reference and secondary must be the same length')
 

--- a/src/hyp3_sdk/hyp3.py
+++ b/src/hyp3_sdk/hyp3.py
@@ -489,12 +489,12 @@ class HyP3:
         Returns:
             A dictionary containing the prepared InSAR ISCE multi burst job
         """
+        if len(reference) != len(secondary):
+            raise ValueError('Reference and secondary must be the same length')
+
         job_parameters = locals().copy()
         for key in ['cls', 'name']:
             job_parameters.pop(key)
-
-        if len(reference) != len(secondary):
-            raise ValueError('Reference and secondary must be the same length')
 
         job_dict = {
             'job_parameters': {**job_parameters},

--- a/tests/test_hyp3.py
+++ b/tests/test_hyp3.py
@@ -3,7 +3,6 @@ import warnings
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urljoin
 
-import pytest
 import responses
 
 import hyp3_sdk

--- a/tests/test_hyp3.py
+++ b/tests/test_hyp3.py
@@ -348,6 +348,9 @@ def test_prepare_insar_isce_multi_burst_job():
     with pytest.raises(ValueError, match='Reference and secondary must be the same length'):
         assert HyP3.prepare_insar_isce_multi_burst_job(reference=['g1', 'g2'], secondary=['g3'])
 
+    with pytest.raises(ValueError, match='Must include at least 1 reference scene and 1 secondary scene'):
+        assert HyP3.prepare_insar_isce_multi_burst_job(reference=[], secondary=[])
+
 
 def test_prepare_aria_s1_gunw_job():
     assert HyP3.prepare_aria_s1_gunw_job(

--- a/tests/test_hyp3.py
+++ b/tests/test_hyp3.py
@@ -345,12 +345,6 @@ def test_prepare_insar_isce_multi_burst_job():
         },
     }
 
-    with pytest.raises(ValueError, match='Reference and secondary must be the same length'):
-        assert HyP3.prepare_insar_isce_multi_burst_job(reference=['g1', 'g2'], secondary=['g3'])
-
-    with pytest.raises(ValueError, match='Must include at least 1 reference scene and 1 secondary scene'):
-        assert HyP3.prepare_insar_isce_multi_burst_job(reference=[], secondary=[])
-
 
 def test_prepare_aria_s1_gunw_job():
     assert HyP3.prepare_aria_s1_gunw_job(

--- a/tests/test_hyp3.py
+++ b/tests/test_hyp3.py
@@ -3,6 +3,7 @@ import warnings
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urljoin
 
+import pytest
 import responses
 
 import hyp3_sdk
@@ -321,6 +322,33 @@ def test_prepare_insar_isce_burst_job():
     }
 
 
+def test_prepare_insar_isce_multi_burst_job():
+    assert HyP3.prepare_insar_isce_multi_burst_job(reference=['g1'], secondary=['g2']) == {
+        'job_type': 'INSAR_ISCE_MULTI_BURST',
+        'job_parameters': {
+            'reference': ['g1'],
+            'secondary': ['g2'],
+            'apply_water_mask': False,
+            'looks': '20x4',
+        },
+    }
+    assert HyP3.prepare_insar_isce_multi_burst_job(
+        reference=['g1', 'g2'], secondary=['g3', 'g4'], name='my_name', apply_water_mask=True, looks='10x2'
+    ) == {
+        'job_type': 'INSAR_ISCE_MULTI_BURST',
+        'name': 'my_name',
+        'job_parameters': {
+            'reference': ['g1', 'g2'],
+            'secondary': ['g3', 'g4'],
+            'apply_water_mask': True,
+            'looks': '10x2',
+        },
+    }
+
+    with pytest.raises(ValueError, match='Reference and secondary must be the same length'):
+        assert HyP3.prepare_insar_isce_multi_burst_job(reference=['g1', 'g2'], secondary=['g3'])
+
+
 def test_prepare_aria_s1_gunw_job():
     assert HyP3.prepare_aria_s1_gunw_job(
         reference=['ref_granule1', 'ref_granule2'], secondary=['sec_granule1', 'sec_granule2'], frame_id=100
@@ -397,6 +425,16 @@ def test_submit_insar_isce_burst_job(get_mock_hyp3, get_mock_job):
     api = get_mock_hyp3()
     responses.add(responses.POST, urljoin(api.url, '/jobs'), json=api_response)
     batch = api.submit_insar_isce_burst_job('g1', 'g2')
+    assert batch.jobs[0] == job
+
+
+@responses.activate
+def test_submit_insar_isce_multi_burst_job(get_mock_hyp3, get_mock_job):
+    job = get_mock_job('INSAR_ISCE_MULTI_BURST', job_parameters={'reference': ['g1', 'g2'], 'secondary': ['g3', 'g4']})
+    api_response = {'jobs': [job.to_dict()]}
+    api = get_mock_hyp3()
+    responses.add(responses.POST, urljoin(api.url, '/jobs'), json=api_response)
+    batch = api.submit_insar_isce_multi_burst_job(['g1', 'g2'], ['g3', 'g4'])
     assert batch.jobs[0] == job
 
 


### PR DESCRIPTION
Only added check to see if reference and secondary are equal length and contain more than 1 granule. Can add <= 15 check but not sure if that will increase/decrease in the future. Probably better to not couple this check to sdk version and leave in the api. 