### PR TITLE
Support EDC Sandbox API URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.5.0]
+
+### Added
+* Added support for specifying a HyP3 API URL with a non-`.asf.alaska.edu` domain name. This is accomplished by updating the domain of the `asf-urs` cookie when creating the `HyP3` object.
+* Added support for specifying a HyP3 API URL that includes a path after the domain name. All API endpoints will be relative to the given path. For example, specifying `https://foo.example.com/api` results in the `/user` endpoint being relative to `/api`, i.e. `https://foo.example.com/api/user`.
+
 ## [7.4.0]
 
 ### Added

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,11 +14,13 @@ from hyp3_sdk.hyp3 import HyP3
 @pytest.fixture(autouse=True)
 def get_mock_hyp3():
     def mock_get_authenticated_session(username, password):
-        return requests.Session()
+        session = requests.Session()
+        session.cookies.set('asf-urs', 'test-cookie', domain='.asf.alaska.edu')
+        return session
 
-    def default_hyp3():
+    def default_hyp3(api_url: str = 'https://dummy-api.asf.alaska.edu'):
         with patch('hyp3_sdk.util.get_authenticated_session', mock_get_authenticated_session):
-            return HyP3()
+            return HyP3(api_url=api_url)
 
     return default_hyp3
 

--- a/tests/test_hyp3.py
+++ b/tests/test_hyp3.py
@@ -564,3 +564,28 @@ def test_update_jobs(get_mock_hyp3, get_mock_job):
 
     with pytest.raises(HyP3Error, match=r'^<Response \[400\]> test error message$'):
         api.update_jobs(job1, foo='bar')
+
+
+def test_get_endpoint_url(get_mock_hyp3):
+    api = get_mock_hyp3(api_url='https://foo.example.com/api')
+    assert api._get_endpoint_url('foo') == 'https://foo.example.com/api/foo'
+    assert api._get_endpoint_url('/foo') == 'https://foo.example.com/api/foo'
+    assert api._get_endpoint_url('///foo///') == 'https://foo.example.com/api/foo'
+
+    api = get_mock_hyp3(api_url='https://foo.example.com/api/')
+    assert api._get_endpoint_url('foo') == 'https://foo.example.com/api/foo'
+    assert api._get_endpoint_url('/foo') == 'https://foo.example.com/api/foo'
+    assert api._get_endpoint_url('///foo///') == 'https://foo.example.com/api/foo'
+
+
+def test_update_cookie(get_mock_hyp3):
+    api = get_mock_hyp3()
+    assert api.session.cookies.get('asf-urs', domain='.asf.alaska.edu') == 'test-cookie'
+
+    api = get_mock_hyp3(api_url='https://foo.example.com:8000/api')
+    assert api.session.cookies.get('asf-urs', domain='.asf.alaska.edu') == 'test-cookie'
+    assert api.session.cookies.get('asf-urs', domain='foo.example.com') == 'test-cookie'
+
+    api = get_mock_hyp3(api_url='https://foo.asf.alaska.edu:8000/api')
+    assert api.session.cookies.get('asf-urs', domain='.asf.alaska.edu') == 'test-cookie'
+    assert api.session.cookies.get('asf-urs', domain='foo.asf.alaska.edu') is None

--- a/tests/test_hyp3.py
+++ b/tests/test_hyp3.py
@@ -567,6 +567,10 @@ def test_update_jobs(get_mock_hyp3, get_mock_job):
 
 
 def test_get_endpoint_url(get_mock_hyp3):
+    api = get_mock_hyp3(api_url='https://dummy-api.asf.alaska.edu')
+    assert api._get_endpoint_url('foo') == 'https://dummy-api.asf.alaska.edu/foo'
+    assert api._get_endpoint_url('/foo') == 'https://dummy-api.asf.alaska.edu/foo'
+
     api = get_mock_hyp3(api_url='https://foo.example.com/api')
     assert api._get_endpoint_url('foo') == 'https://foo.example.com/api/foo'
     assert api._get_endpoint_url('/foo') == 'https://foo.example.com/api/foo'
@@ -576,6 +580,9 @@ def test_get_endpoint_url(get_mock_hyp3):
     assert api._get_endpoint_url('foo') == 'https://foo.example.com/api/foo'
     assert api._get_endpoint_url('/foo') == 'https://foo.example.com/api/foo'
     assert api._get_endpoint_url('///foo///') == 'https://foo.example.com/api/foo'
+
+    api = get_mock_hyp3(api_url='https://foo.example.com:8000/api/')
+    assert api._get_endpoint_url('foo') == 'https://foo.example.com:8000/api/foo'
 
 
 def test_update_cookie(get_mock_hyp3):


### PR DESCRIPTION
TODO:

- [x] Tests
- [x] Changelog
- [x] Validate against `https://hyp3-test-api.asf.alaska.edu` and edc-sandbox URL