### PR TITLE
Handle jobs with bucket and bucket_prefix specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.7.7]
+
+### Changed
+* `Job` class instances now have `job.bucket` and `job.bucket_prefix` parameters, and they are preserved in the job dictionary returned with the `job.to_dict()` method. 
+  * `job.bucket` and `job.bucket_prefix` can be either a `str` or `None` for backwards compatibility.
+  * `job.to_dict(for_resubmit=True)` will emit a user warning about bucket prefixes that have likely been expanded and my need to be reset for resubmission.  
+* `Job.from_dict()` class methods now sets the `job.bucket` and `job.bucket_prefix` parameters. 
+
 ## [7.7.6]
 
 ### Changed

--- a/src/hyp3_sdk/jobs.py
+++ b/src/hyp3_sdk/jobs.py
@@ -1,3 +1,4 @@
+import warnings
 from collections import Counter
 from collections.abc import Sequence
 from datetime import datetime
@@ -15,7 +16,7 @@ from hyp3_sdk.util import download_file, get_tqdm_progress_bar
 # TODO: actually looks like a good candidate for a dataclass (python 3.7+)
 #       https://docs.python.org/3/library/dataclasses.html
 class Job:
-    _attributes_for_resubmit = {'name', 'job_parameters', 'job_type'}
+    _attributes_for_resubmit = {'name', 'bucket', 'bucket_prefix', 'job_parameters', 'job_type'}
 
     def __init__(
         self,
@@ -25,6 +26,8 @@ class Job:
         status_code: str,
         user_id: str,
         name: str | None = None,
+        bucket: str | None = None,
+        bucket_prefix: str | None = None,
         job_parameters: dict | None = None,
         files: list | None = None,
         logs: list | None = None,
@@ -41,6 +44,8 @@ class Job:
         self.status_code = status_code
         self.user_id = user_id
         self.name = name
+        self.bucket = bucket
+        self.bucket_prefix = bucket_prefix
         self.job_parameters = job_parameters
         self.files = files
         self.logs = logs
@@ -70,6 +75,8 @@ class Job:
             status_code=input_dict['status_code'],
             user_id=input_dict['user_id'],
             name=input_dict.get('name'),
+            bucket=input_dict.get('bucket'),
+            bucket_prefix=input_dict.get('bucket_prefix'),
             job_parameters=input_dict.get('job_parameters'),
             files=input_dict.get('files'),
             logs=input_dict.get('logs'),
@@ -85,6 +92,13 @@ class Job:
         job_dict = {}
         if for_resubmit:
             keys_to_process = Job._attributes_for_resubmit
+            if self.bucket_prefix is not None and self.bucket_prefix != self.job_id:
+                warnings.warn(
+                    'Custom bucket prefix detected! Bucket prefix may have been expanded; '
+                    'if you used an expansion for your bucket prefix (e.g., `"{name}"` or `"{job_id}"`), '
+                    'you may need to reset your bucket_prefix before submitting!',
+                    UserWarning,
+                )
         else:
             keys_to_process = set(vars(self).keys())
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,4 +1,4 @@
-from copy import copy
+from copy import copy, deepcopy
 from datetime import datetime, timedelta
 
 import pytest
@@ -23,6 +23,8 @@ SUCCEEDED_JOB = {
     },
     'job_type': 'PAIR_PROCESS',
     'name': 'test_success',
+    'bucket': 'hyp3-content-bucket',
+    'bucket_prefix': 'd1c05104-b455-4f35-a95a-84155d63f855',
     'request_time': '2020-09-22T23:55:10+00:00',
     'status_code': 'SUCCEEDED',
     'thumbnail_images': ['https://PAIR_PROCESS_thumb.png'],
@@ -42,6 +44,8 @@ FAILED_JOB = {
     },
     'job_type': 'PAIR_PROCESS',
     'name': 'test_failure',
+    'bucket': 'hyp3-content-bucket',
+    'bucket_prefix': 'd1c05104-b455-4f35-a95a-84155d63f855',
     'request_time': '2020-09-22T23:55:10+00:00',
     'status_code': 'FAILED',
     'user_id': 'asf_hyp3',
@@ -63,6 +67,12 @@ def test_job_attributes():
     for key in unprovided_attributes:
         assert job.__getattribute__(key) is None
 
+    no_bucket_job_dict = deepcopy(SUCCEEDED_JOB)
+    del no_bucket_job_dict['bucket'], no_bucket_job_dict['bucket_prefix']
+    job = Job.from_dict(no_bucket_job_dict)
+    assert job.bucket is None
+    assert job.bucket_prefix is None
+
 
 def test_job_dict_transforms():
     job = Job.from_dict(SUCCEEDED_JOB)
@@ -76,6 +86,22 @@ def test_job_dict_transforms():
 
     retry = job.to_dict(for_resubmit=True)
     assert retry.keys() == Job._attributes_for_resubmit
+
+    custom_bucket_job_dict = deepcopy(SUCCEEDED_JOB)
+    custom_bucket_job_dict['bucket'] = 'some-bucket'
+    job = Job.from_dict(custom_bucket_job_dict)
+    assert job.to_dict() == custom_bucket_job_dict
+
+    retry = job.to_dict(for_resubmit=True)
+    assert retry.keys() == Job._attributes_for_resubmit
+
+    custom_bucket_job_dict['bucket_prefix'] = 'some-prefix'
+    job = Job.from_dict(custom_bucket_job_dict)
+    assert job.to_dict() == custom_bucket_job_dict
+
+    with pytest.warns(UserWarning):
+        retry = job.to_dict(for_resubmit=True)
+        assert retry.keys() == Job._attributes_for_resubmit
 
 
 def test_job_complete_succeeded_failed_running():


### PR DESCRIPTION
This:
*  updates the SDK to handle jobs with bucket and bucket prefix specified and allow projects/deployments testing these parameters to see/use them with the SDK (they are currently ignored or hidden). 
* does _not_ yet add the bucket and bucket_prefix parameters to the `prepare_*_job` and `submit_*_job` methods pending documentation and a full rollout.