### PR TITLE
Update hyp3.find_jobs datetime string handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [7.7.8]
 
+### Added
+* `HyP3.find_jobs` now allows passing partial datetime strings to the `start` and `end` paramters matching the behavior when passing datetime objects.
+
 ### Fixed
 * `job.bucket_prefix`'s that originally included an expansion (`{name}` and/or `{job_id}`) will be un-expanded when calling `job.to_dict(for_resubmit=True)`, and an expansion warning is no longer emitted.
 * Deprecated `match_querystring` usage in `test/test_hyp3.py` in favor of `matchers.query_param_matcher()`.

--- a/src/hyp3_sdk/hyp3.py
+++ b/src/hyp3_sdk/hyp3.py
@@ -2,7 +2,7 @@ import math
 import time
 import warnings
 from copy import deepcopy
-from datetime import datetime, timezone
+from datetime import datetime
 from functools import singledispatchmethod
 from getpass import getpass
 from typing import Literal
@@ -82,8 +82,8 @@ class HyP3:
 
     def find_jobs(
         self,
-        start: datetime | None = None,
-        end: datetime | None = None,
+        start: datetime | str | None = None,
+        end: datetime | str | None = None,
         status_code: str | None = None,
         name: str | None = None,
         job_type: str | None = None,
@@ -102,16 +102,17 @@ class HyP3:
         Returns:
             A Batch object containing the found jobs
         """
-        params = {}
-        for param_name in ('start', 'end', 'status_code', 'name', 'job_type', 'user_id'):
-            param_value = locals().get(param_name)
-            if param_value is not None:
-                if isinstance(param_value, datetime):
-                    if param_value.tzinfo is None:
-                        param_value = param_value.replace(tzinfo=timezone.utc)
-                    param_value = param_value.isoformat(timespec='seconds')
 
-                params[param_name] = param_value
+        params = {
+            'start': None if start is None else hyp3_sdk.util._get_normalized_datetime_str(start),
+            'end': None if end is None else hyp3_sdk.util._get_normalized_datetime_str(end),
+            'status_code': status_code,
+            'name': name,
+            'job_type': job_type,
+            'user_id': user_id,
+        }
+        # Filter out None values
+        params = {k: v for k, v in params.items() if v is not None}
 
         response = self.session.get(self._get_endpoint_url('/jobs'), params=params)
         _raise_for_hyp3_status(response)

--- a/src/hyp3_sdk/util.py
+++ b/src/hyp3_sdk/util.py
@@ -2,11 +2,13 @@
 
 import urllib.parse
 from collections.abc import Generator, Sequence
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from zipfile import ZipFile
 
 import requests
+from dateutil.parser import parse as parse_date
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
@@ -19,6 +21,16 @@ AUTH_URL = (
 )
 
 PROFILE_URL = 'https://urs.earthdata.nasa.gov/profile'
+
+
+def _get_normalized_datetime_str(dt: datetime | str) -> str:
+    if isinstance(dt, str):
+        dt = parse_date(dt)
+
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+
+    return dt.isoformat(timespec='seconds')
 
 
 def extract_zipped_product(zip_file: str | Path, delete: bool = True) -> Path:

--- a/tests/test_hyp3.py
+++ b/tests/test_hyp3.py
@@ -143,6 +143,13 @@ def test_find_jobs_start(get_mock_hyp3):
     batch = api.find_jobs(start=datetime(2021, 1, 1, tzinfo=timezone.utc))
     assert len(batch) == 0
 
+    batch = api.find_jobs(start='2021-01-01')
+    assert len(batch) == 0
+
+    batch = api.find_jobs(start='2021-01-01T00:00:00+00:00')
+    assert len(batch) == 0
+
+
 
 @responses.activate
 def test_find_jobs_end(get_mock_hyp3):
@@ -160,6 +167,13 @@ def test_find_jobs_end(get_mock_hyp3):
 
     batch = api.find_jobs(end=datetime(2021, 1, 2, tzinfo=timezone.utc))
     assert len(batch) == 0
+
+    batch = api.find_jobs(end='2021-01-02')
+    assert len(batch) == 0
+
+    batch = api.find_jobs(end='2021-01-02T00:00:00+00:00')
+    assert len(batch) == 0
+
 
 
 @responses.activate

--- a/tests/test_hyp3.py
+++ b/tests/test_hyp3.py
@@ -150,7 +150,6 @@ def test_find_jobs_start(get_mock_hyp3):
     assert len(batch) == 0
 
 
-
 @responses.activate
 def test_find_jobs_end(get_mock_hyp3):
     api = get_mock_hyp3()
@@ -173,7 +172,6 @@ def test_find_jobs_end(get_mock_hyp3):
 
     batch = api.find_jobs(end='2021-01-02T00:00:00+00:00')
     assert len(batch) == 0
-
 
 
 @responses.activate


### PR DESCRIPTION
Currently, `hyp3.find_jobs` is type-hinted such that only datetime objects are valid for the `start` and `end` parameters. 

However, the current code does allow you to pass strings through if you have a fully qualified datetime (with timezone info).

This PR expanded the type-hinting to include strings and support passing partial datetime strings, matching the behavior of datetime objects. 

| start/end value | current behavior | new behavior |
|------------------------|--------------------------|---------------------|
| `datetime(2026, 10, 21)` | :heavy_check_mark: |:heavy_check_mark: |
| `"2026-10-21"` | HTTP 400 |:heavy_check_mark: |
| `datetime(2026, 10, 21, tzinfo=timezone.utc)` | :heavy_check_mark: |:heavy_check_mark: |
| `"2021-01-01T00:00:00+00:00"` | :heavy_check_mark: |:heavy_check_mark: |
| `"2021-01-01T00:00:00Z"` | :heavy_check_mark: |:heavy_check_mark: |